### PR TITLE
Fix EBADF error using broadcast

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -129,6 +129,10 @@
     osc.UDPPort = function (options) {
         osc.Port.call(this, options);
 
+        this.options.localAddress = this.options.localAddress || "127.0.0.1";
+        this.options.localPort = this.options.localPort !== undefined ?
+            this.options.localPort : 57121;
+
         this.on("open", this.listen.bind(this));
     };
 

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -129,10 +129,6 @@
     osc.UDPPort = function (options) {
         osc.Port.call(this, options);
 
-        this.options.localAddress = this.options.localAddress || "127.0.0.1";
-        this.options.localPort = this.options.localPort !== undefined ?
-            this.options.localPort : 57121;
-
         this.on("open", this.listen.bind(this));
     };
 
@@ -144,16 +140,19 @@
         this.socket = dgram.createSocket("udp4");
 
         function onBound() {
+            if ( that.options.multicast ) {
+              that.socket.setBroadcast(that.options.multicast);
+              that.socket.setMulticastTTL(that.options.multicastTTL);
+            }
+
+            if ( that.options.broadcast ) {
+              that.socket.setBroadcast(that.options.broadcast);
+            }
+
             that.emit("open", that.socket);
         }
 
-        if (this.options.multicast) {
-            this.socket.setBroadcast(this.options.multicast);
-            this.socket.setMulticastTTL(this.options.multicastTTL);
-            this.socket.bind(this.options.localPort, onBound);
-        } else {
-            this.socket.bind(this.options.localPort, this.options.localAddress, onBound);
-        }
+        this.socket.bind(this.options.localPort, this.options.localAddress, onBound);
     };
 
     p.listen = function () {

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -133,6 +133,10 @@
         this.options.localPort = this.options.localPort !== undefined ?
             this.options.localPort : 57121;
 
+        this.options.remoteAddress = this.options.remoteAddress || "127.0.0.1";
+        this.options.remotePort = this.options.remotePort !== undefined ?
+            this.options.remotePort : 57121;
+
         this.on("open", this.listen.bind(this));
     };
 

--- a/tests/node-transport-tests.js
+++ b/tests/node-transport-tests.js
@@ -22,8 +22,6 @@ var testMessage = {
 
 function createUDPServer(onMessage, o) {
     o = o || {};
-    o.localAddress = o.remoteAddress = "127.0.0.1";
-    o.localPort = o.remotePort = 57121;
 
     var oscUDP = new osc.UDPPort(o);
 
@@ -45,6 +43,32 @@ jqUnit.asyncTest("Send a message via a UDP socket", function () {
         oscUDP.close();
         jqUnit.start();
     });
+
+    oscUDP.on("ready", function () {
+        oscUDP.send(testMessage);
+    });
+});
+
+jqUnit.asyncTest("Send a multicast message via a UDP socket", function() {
+    var oscUDP = createUDPServer(function (msg) {
+        QUnit.deepEqual(msg, testMessage,
+            "The message should have been sent to the web socket.");
+        oscUDP.close();
+        jqUnit.start();
+    }, { multicast: true, multicastTTL: 2 } );
+
+    oscUDP.on("ready", function () {
+        oscUDP.send(testMessage);
+    });
+});
+
+jqUnit.asyncTest("Send a broadcast message via a UDP socket", function() {
+    var oscUDP = createUDPServer(function (msg) {
+        QUnit.deepEqual(msg, testMessage,
+            "The message should have been sent to the web socket.");
+        oscUDP.close();
+        jqUnit.start();
+    }, { broadcast: true, localAddress: '0.0.0.0', remoteAddress: "255.255.255.255" } );
 
     oscUDP.on("ready", function () {
         oscUDP.send(testMessage);


### PR DESCRIPTION
Broadcast was unusable because setBroadcast has to be set after the socket is opened or it results in an EBADF error.

I also added a broadcast option, since it was unclear that the multicast option would turn on broadcast. Lastly, I removed the custom defaults to local address and local port because they are inconsistent with the expected behavior of dgram, which defaults to listening on all interfaces (0.0.0.0) instead of just localhost.

A working broadcast example now looks like this:

````
var osc = require('osc');

var oscPort = new osc.UDPPort({
  localPort: 5000,
  remoteAddress: '192.168.1.255',
  remotePort: 5000,
  broadcast: true
});
oscPort.on("open", function(socket) {
  setInterval( function() {
    oscPort.send({
      address: "/test",
      args: []
    });
  }, 1000 );
});

oscPort.open();
````

And to test reception:

````
var port = process.argv[2]
  , address = '0.0.0.0'
  , dgram = require('dgram')
;

if ( port === undefined ) {
  console.log( "Please specify a port." );
  console.log( process.argv[1] + " [PORT]" );
  process.exit(1);
}

var server = dgram.createSocket('udp4')
server.on("listening", function() {
  var a = server.address();
  console.log( "Listening on " + a.address + ":" + a.port );
});

server.on("message", function(message, remote) {
  console.log( remote.address + ":" + remote.port + " - " + message );
});

server.bind(port, address);
````