### PR TITLE
Pass extra packet information through from ports.

### DIFF
--- a/src/osc-transports.js
+++ b/src/osc-transports.js
@@ -18,20 +18,20 @@ var osc = osc || require("./osc.js"),
     "use strict";
 
     // Unsupported, non-API function.
-    osc.firePacketEvents = function (port, packet, timeTag) {
+    osc.firePacketEvents = function (port, packet, timeTag, packetInfo) {
         if (packet.address) {
-            port.emit("message", packet, timeTag);
+            port.emit("message", packet, timeTag, packetInfo);
         } else {
-            osc.fireBundleEvents(port, packet, timeTag);
+            osc.fireBundleEvents(port, packet, timeTag, packetInfo);
         }
     };
 
     // Unsupported, non-API function.
-    osc.fireBundleEvents = function (port, bundle, timeTag) {
-        port.emit("bundle", bundle, timeTag);
+    osc.fireBundleEvents = function (port, bundle, timeTag, packetInfo) {
+        port.emit("bundle", bundle, timeTag, packetInfo);
         for (var i = 0; i < bundle.packets.length; i++) {
             var packet = bundle.packets[i];
-            osc.firePacketEvents(port, packet, bundle.timeTag);
+            osc.firePacketEvents(port, packet, bundle.timeTag, packetInfo);
         }
     };
 
@@ -69,12 +69,12 @@ var osc = osc || require("./osc.js"),
 
     p.decodeOSC = function (data, packetInfo) {
         data = osc.byteArray(data);
-        this.emit("raw", data);
+        this.emit("raw", data, packetInfo);
 
         try {
             var packet = osc.readPacket(data, this.options);
-            this.emit("osc", packet);
-            osc.firePacketEvents(this, packet);
+            this.emit("osc", packet, packetInfo);
+            osc.firePacketEvents(this, packet, undefined, packetInfo);
         } catch (err) {
             this.emit("error", err);
         }
@@ -117,6 +117,7 @@ var osc = osc || require("./osc.js"),
     };
 
     p.decodeSLIPData = function (data, packetInfo) {
+        // TODO: Get packetInfo through SLIP decoder.
         this.decoder.decode(data);
     };
 

--- a/src/osc-transports.js
+++ b/src/osc-transports.js
@@ -118,7 +118,7 @@ var osc = osc || require("./osc.js"),
 
     p.decodeSLIPData = function (data, packetInfo) {
         // TODO: Get packetInfo through SLIP decoder.
-        this.decoder.decode(data);
+        this.decoder.decode(data, packetInfo);
     };
 
 

--- a/src/osc-transports.js
+++ b/src/osc-transports.js
@@ -67,7 +67,7 @@ var osc = osc || require("./osc.js"),
         return encoded;
     };
 
-    p.decodeOSC = function (data) {
+    p.decodeOSC = function (data, packetInfo) {
         data = osc.byteArray(data);
         this.emit("raw", data);
 
@@ -116,7 +116,7 @@ var osc = osc || require("./osc.js"),
         return framed;
     };
 
-    p.decodeSLIPData = function (data) {
+    p.decodeSLIPData = function (data, packetInfo) {
         this.decoder.decode(data);
     };
 

--- a/src/platforms/osc-browser.js
+++ b/src/platforms/osc-browser.js
@@ -48,7 +48,7 @@ var osc = osc;
     p.listen = function () {
         var that = this;
         this.socket.onmessage = function (e) {
-            that.emit("data", e.data);
+            that.emit("data", e.data, e);
         };
 
         this.socket.onerror = function (err) {

--- a/src/platforms/osc-chromeapp.js
+++ b/src/platforms/osc-chromeapp.js
@@ -18,7 +18,7 @@ var osc = osc || {};
     osc.listenToTransport = function (that, transport, idName) {
         transport.onReceive.addListener(function (e) {
             if (e[idName] === that[idName]) {
-                that.emit("data", e.data);
+                that.emit("data", e.data, e);
             }
         });
 

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -90,7 +90,7 @@
         var that = this;
 
         this.serialPort.on("data", function (data) {
-            that.emit("data", data);
+            that.emit("data", data, undefined);
         });
 
         this.serialPort.on("error", function (err) {
@@ -278,7 +278,7 @@
     p.listen = function () {
         var that = this;
         this.socket.on("message", function (data) {
-            that.emit("data", data);
+            that.emit("data", data, undefined);
         });
 
         this.socket.on("error", function (err) {
@@ -355,7 +355,7 @@
     p.listen = function () {
         var that = this;
         this.socket.on("data", function (msg) {
-            that.emit("data", msg);
+            that.emit("data", msg, undefined);
         });
 
         this.socket.on("error", function (err) {


### PR DESCRIPTION
This fixes #45, by adding an extra argument, `packetInfo` to the `data`, `raw`, `osc`, `bundle` and `message` events, which contains the original data from the packet.

The packet info differs by port implementation:
* For WebSockets, it is a [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent)
* For UDP, it is a [rinfo](https://nodejs.org/api/dgram.html#dgram_event_message) object.
* For TCP and Serial it's undefined.

One issue with this implementation is that if the packet is decoded using the SLIP decoder, the packet info is lost. This isn't a major issue, as `TCPPort` and `SerialPort` are the only ports which extend `SLIPPort` and they don't have any packet info.