### PR TITLE
Fix sending over UDP with Electron

### DIFF
--- a/src/osc.js
+++ b/src/osc.js
@@ -112,7 +112,7 @@ var osc = osc || {};
      */
     // Unsupported, non-API function.
     osc.nativeBuffer = function (obj) {
-        if (osc.isBufferEnv && osc.isNode) {
+        if (osc.isBufferEnv || osc.isNode) {
             return osc.isBuffer(obj) ? obj : new Buffer(obj.buffer ? obj : new Uint8Array(obj));
         }
 


### PR DESCRIPTION
Electron doesn't show up as a Node environment (osc.isNode) but it is a buffer environment. (os.isBufferEnv). Fixes #65.