### PR TITLE
Error handling for udp port open.

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -179,6 +179,10 @@
             that.emit("open", that.socket);
         }
 
+        this.socket.on("error", function (error) {
+            that.emit("error", error);
+        });
+
         this.socket.bind(this.options.localPort, this.options.localAddress, onBound);
     };
 
@@ -190,10 +194,6 @@
         var that = this;
         this.socket.on("message", function (msg, rinfo) {
             that.emit("data", msg, rinfo);
-        });
-
-        this.socket.on("error", function (error) {
-            that.emit("error", error);
         });
 
         this.socket.on("close", function () {


### PR DESCRIPTION
Moves udp socket error handler before socket.bind.
This way it is possible to catch error events that occur while opening the udp port, e.g.
“Uncaught Error: bind EACCES …”

It might make sense to also move the error handlers for other port types.
As I have no experience with the other port types, I have not changed them.
