### PR TITLE
fix Node.js serialport library open contract

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -86,13 +86,15 @@
             autoOpen: false
         });
 
-        this.serialPort.open(function(err) {
-            if (err) {
-              that.emit("error", err);
-            } else {
-              that.emit("open", that.serialPort);
-            }
+        this.serialPort.on("error", function (err) {
+            that.emit("error", err);
         });
+
+        this.serialPort.once("open", function () {
+            that.emit("open", that.serialPort);
+        });
+
+        this.serialPort.open();
     };
 
     p.listen = function () {
@@ -100,10 +102,6 @@
 
         this.serialPort.on("data", function (data) {
             that.emit("data", data, undefined);
-        });
-
-        this.serialPort.on("error", function (err) {
-            that.emit("error", err);
         });
 
         this.serialPort.on("close", function (err) {

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -86,8 +86,12 @@
             autoOpen: false
         });
 
-        this.serialPort.open(function() {
-            that.emit("open", that.serialPort);
+        this.serialPort.open(function(err) {
+            if (err) {
+              that.emit("error", err);
+            } else {
+              that.emit("open", that.serialPort);
+            }
         });
     };
 


### PR DESCRIPTION
serialport `open` method is called with an error if opening failed

Example:

On Ubuntu if the user is not a member of the dialout group.