### PR TITLE
Improves upon gh-94's fix for serialport open contract

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -90,7 +90,7 @@
             that.emit("error", err);
         });
 
-        this.serialPort.once("open", function () {
+        this.serialPort.on("open", function () {
             that.emit("open", that.serialPort);
         });
 
@@ -104,12 +104,8 @@
             that.emit("data", data, undefined);
         });
 
-        this.serialPort.on("close", function (err) {
-            if (err) {
-                that.emit("error", err);
-            } else {
-                that.emit("close");
-            }
+        this.serialPort.on("close", function () {
+            that.emit("close");
         });
 
         that.emit("ready");
@@ -122,11 +118,7 @@
         }
 
         var that = this;
-        this.serialPort.write(encoded, function (err) {
-            if (err) {
-                that.emit("error", err);
-            }
-        });
+        this.serialPort.write(encoded);
     };
 
     p.close = function () {


### PR DESCRIPTION
This version binds the "open" event listener using <code>on()</code> instead of <code>once()</code> (in practice it doesn't make a different, I think, and we might as well be consistent). Also tidies up the code and removes other similar callbacks passed to the serialPort API that were emitting our error event in favour of the single, generic "error" listener.

Thanks again to @sonnyp for the original fix!