### PR TITLE
Fix using with pkg

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -13,20 +13,6 @@
 (function () {
     "use strict";
 
-    var requireModules = function (paths) {
-        if (paths.forEach === undefined) {
-            paths = [paths];
-        }
-
-        var modules = [];
-        paths.forEach(function (path) {
-            var module = require(path);
-            modules.push(module);
-        });
-
-        return modules;
-    };
-
     var shallowMerge = function (target, toMerge) {
         target = target || {};
         if (toMerge.forEach === undefined) {
@@ -46,11 +32,11 @@
         SerialPort = require("serialport"),
         net = require("net"),
         WebSocket = require("ws"),
-        modules = requireModules([
-            "../osc.js",
-            "../osc-transports.js",
-            "./osc-websocket-client.js"
-        ]),
+        modules = [
+            require("../osc.js"),
+            require("../osc-transports.js"),
+            require("./osc-websocket-client.js")
+        ],
         osc = shallowMerge({}, modules);
 
     /**********


### PR DESCRIPTION
I am using this lib in a project that I am building to an exe with https://github.com/zeit/pkg

pkg is unable to handle the way that require was being called and so it is not possible to build an exe that runs. 

This change resolves the issue so that it can be done properly