### PR TITLE
update dependencies

### DIFF
--- a/dist/osc-browser.min.js
+++ b/dist/osc-browser.min.js
@@ -126,7 +126,7 @@ var osc = osc || {};
     }, osc.timeTag = function(e, t) {
         e = e || 0;
         var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), i = r - n, s = Math.floor(e), o = i + (e - s);
-        if (o > 1) {
+        if (1 < o) {
             var a = Math.floor(o);
             s += a, o = o - a;
         }
@@ -360,127 +360,127 @@ var osc = osc || {};
 }(), function(e, t) {
     "object" == typeof exports && "object" == typeof module ? module.exports = t() : "function" == typeof define && define.amd ? define([], t) : "object" == typeof exports ? exports.Long = t() : e.Long = t();
 }("undefined" != typeof self ? self : this, function() {
-    return function(e) {
-        function t(n) {
-            if (r[n]) return r[n].exports;
-            var i = r[n] = {
-                i: n,
+    return function(r) {
+        function n(e) {
+            if (i[e]) return i[e].exports;
+            var t = i[e] = {
+                i: e,
                 l: !1,
                 exports: {}
             };
-            return e[n].call(i.exports, i, i.exports, t), i.l = !0, i.exports;
+            return r[e].call(t.exports, t, t.exports, n), t.l = !0, t.exports;
         }
-        var r = {};
-        return t.m = e, t.c = r, t.d = function(e, r, n) {
-            t.o(e, r) || Object.defineProperty(e, r, {
+        var i = {};
+        return n.m = r, n.c = i, n.d = function(e, t, r) {
+            n.o(e, t) || Object.defineProperty(e, t, {
                 configurable: !1,
                 enumerable: !0,
-                get: n
+                get: r
             });
-        }, t.n = function(e) {
-            var r = e && e.__esModule ? function() {
+        }, n.n = function(e) {
+            var t = e && e.__esModule ? function() {
                 return e.default;
             } : function() {
                 return e;
             };
-            return t.d(r, "a", r), r;
-        }, t.o = function(e, t) {
+            return n.d(t, "a", t), t;
+        }, n.o = function(e, t) {
             return Object.prototype.hasOwnProperty.call(e, t);
-        }, t.p = "", t(t.s = 0);
+        }, n.p = "", n(n.s = 0);
     }([ function(e, t) {
-        function r(e, t, r) {
+        function n(e, t, r) {
             this.low = 0 | e, this.high = 0 | t, this.unsigned = !!r;
         }
-        function n(e) {
+        function g(e) {
             return !0 === (e && e.__isLong__);
         }
-        function i(e, t) {
+        function r(e, t) {
             var r, n, i;
-            return t ? (i = 0 <= (e >>>= 0) && e < 256) && (n = f[e]) ? n : (r = o(e, (0 | e) < 0 ? -1 : 0, !0), 
-            i && (f[e] = r), r) : (i = -128 <= (e |= 0) && e < 128) && (n = h[e]) ? n : (r = o(e, e < 0 ? -1 : 0, !1), 
-            i && (h[e] = r), r);
+            return t ? (i = 0 <= (e >>>= 0) && e < 256) && (n = o[e]) ? n : (r = p(e, (0 | e) < 0 ? -1 : 0, !0), 
+            i && (o[e] = r), r) : (i = -128 <= (e |= 0) && e < 128) && (n = s[e]) ? n : (r = p(e, e < 0 ? -1 : 0, !1), 
+            i && (s[e] = r), r);
         }
-        function s(e, t) {
-            if (isNaN(e)) return t ? w : y;
+        function l(e, t) {
+            if (isNaN(e)) return t ? c : m;
             if (t) {
-                if (e < 0) return w;
-                if (e >= l) return A;
+                if (e < 0) return c;
+                if (a <= e) return A;
             } else {
-                if (e <= -p) return P;
-                if (e + 1 >= p) return S;
+                if (e <= -u) return P;
+                if (u <= e + 1) return S;
             }
-            return e < 0 ? s(-e, t).neg() : o(e % g | 0, e / g | 0, t);
+            return e < 0 ? l(-e, t).neg() : p(e % i | 0, e / i | 0, t);
         }
-        function o(e, t, n) {
-            return new r(e, t, n);
+        function p(e, t, r) {
+            return new n(e, t, r);
         }
-        function a(e, t, r) {
+        function h(e, t, r) {
             if (0 === e.length) throw Error("empty string");
-            if ("NaN" === e || "Infinity" === e || "+Infinity" === e || "-Infinity" === e) return y;
+            if ("NaN" === e || "Infinity" === e || "+Infinity" === e || "-Infinity" === e) return m;
             if ("number" == typeof t ? (r = t, t = !1) : t = !!t, (r = r || 10) < 2 || 36 < r) throw RangeError("radix");
             var n;
-            if ((n = e.indexOf("-")) > 0) throw Error("interior hyphen");
-            if (0 === n) return a(e.substring(1), t, r).neg();
-            for (var i = s(d(r, 8)), o = y, u = 0; u < e.length; u += 8) {
-                var c = Math.min(8, e.length - u), h = parseInt(e.substring(u, u + c), r);
-                if (c < 8) {
-                    var f = s(d(r, c));
-                    o = o.mul(f).add(s(h));
-                } else o = (o = o.mul(i)).add(s(h));
+            if (0 < (n = e.indexOf("-"))) throw Error("interior hyphen");
+            if (0 === n) return h(e.substring(1), t, r).neg();
+            for (var i = l(f(r, 8)), s = m, o = 0; o < e.length; o += 8) {
+                var a = Math.min(8, e.length - o), u = parseInt(e.substring(o, o + a), r);
+                if (a < 8) {
+                    var c = l(f(r, a));
+                    s = s.mul(c).add(l(u));
+                } else s = (s = s.mul(i)).add(l(u));
             }
-            return o.unsigned = t, o;
+            return s.unsigned = t, s;
         }
-        function u(e, t) {
-            return "number" == typeof e ? s(e, t) : "string" == typeof e ? a(e, t) : o(e.low, e.high, "boolean" == typeof t ? t : e.unsigned);
+        function v(e, t) {
+            return "number" == typeof e ? l(e, t) : "string" == typeof e ? h(e, t) : p(e.low, e.high, "boolean" == typeof t ? t : e.unsigned);
         }
-        e.exports = r;
-        var c = null;
+        e.exports = n;
+        var y = null;
         try {
-            c = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array([ 0, 97, 115, 109, 1, 0, 0, 0, 1, 13, 2, 96, 0, 1, 127, 96, 4, 127, 127, 127, 127, 1, 127, 3, 7, 6, 0, 1, 1, 1, 1, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 50, 6, 3, 109, 117, 108, 0, 1, 5, 100, 105, 118, 95, 115, 0, 2, 5, 100, 105, 118, 95, 117, 0, 3, 5, 114, 101, 109, 95, 115, 0, 4, 5, 114, 101, 109, 95, 117, 0, 5, 8, 103, 101, 116, 95, 104, 105, 103, 104, 0, 0, 10, 191, 1, 6, 4, 0, 35, 0, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 126, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 127, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 128, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 129, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 130, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11 ])), {}).exports;
+            y = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array([ 0, 97, 115, 109, 1, 0, 0, 0, 1, 13, 2, 96, 0, 1, 127, 96, 4, 127, 127, 127, 127, 1, 127, 3, 7, 6, 0, 1, 1, 1, 1, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 50, 6, 3, 109, 117, 108, 0, 1, 5, 100, 105, 118, 95, 115, 0, 2, 5, 100, 105, 118, 95, 117, 0, 3, 5, 114, 101, 109, 95, 115, 0, 4, 5, 114, 101, 109, 95, 117, 0, 5, 8, 103, 101, 116, 95, 104, 105, 103, 104, 0, 0, 10, 191, 1, 6, 4, 0, 35, 0, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 126, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 127, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 128, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 129, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 130, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11 ])), {}).exports;
         } catch (e) {}
-        r.prototype.__isLong__, Object.defineProperty(r.prototype, "__isLong__", {
+        Object.defineProperty(n.prototype, "__isLong__", {
             value: !0
-        }), r.isLong = n;
-        var h = {}, f = {};
-        r.fromInt = i, r.fromNumber = s, r.fromBits = o;
-        var d = Math.pow;
-        r.fromString = a, r.fromValue = u;
-        var g = 4294967296, l = g * g, p = l / 2, v = i(1 << 24), y = i(0);
-        r.ZERO = y;
-        var w = i(0, !0);
-        r.UZERO = w;
-        var m = i(1);
-        r.ONE = m;
-        var b = i(1, !0);
-        r.UONE = b;
-        var E = i(-1);
-        r.NEG_ONE = E;
-        var S = o(-1, 2147483647, !1);
-        r.MAX_VALUE = S;
-        var A = o(-1, -1, !0);
-        r.MAX_UNSIGNED_VALUE = A;
-        var P = o(0, -2147483648, !1);
-        r.MIN_VALUE = P;
-        var B = r.prototype;
+        }), n.isLong = g;
+        var s = {}, o = {};
+        n.fromInt = r, n.fromNumber = l, n.fromBits = p;
+        var f = Math.pow;
+        n.fromString = h, n.fromValue = v;
+        var i = 4294967296, a = i * i, u = a / 2, w = r(1 << 24), m = r(0);
+        n.ZERO = m;
+        var c = r(0, !0);
+        n.UZERO = c;
+        var d = r(1);
+        n.ONE = d;
+        var b = r(1, !0);
+        n.UONE = b;
+        var E = r(-1);
+        n.NEG_ONE = E;
+        var S = p(-1, 2147483647, !1);
+        n.MAX_VALUE = S;
+        var A = p(-1, -1, !0);
+        n.MAX_UNSIGNED_VALUE = A;
+        var P = p(0, -2147483648, !1);
+        n.MIN_VALUE = P;
+        var B = n.prototype;
         B.toInt = function() {
             return this.unsigned ? this.low >>> 0 : this.low;
         }, B.toNumber = function() {
-            return this.unsigned ? (this.high >>> 0) * g + (this.low >>> 0) : this.high * g + (this.low >>> 0);
+            return this.unsigned ? (this.high >>> 0) * i + (this.low >>> 0) : this.high * i + (this.low >>> 0);
         }, B.toString = function(e) {
             if ((e = e || 10) < 2 || 36 < e) throw RangeError("radix");
             if (this.isZero()) return "0";
             if (this.isNegative()) {
                 if (this.eq(P)) {
-                    var t = s(e), r = this.div(t), n = r.mul(t).sub(this);
+                    var t = l(e), r = this.div(t), n = r.mul(t).sub(this);
                     return r.toString(e) + n.toInt().toString(e);
                 }
                 return "-" + this.neg().toString(e);
             }
-            for (var i = s(d(e, 6), this.unsigned), o = this, a = ""; ;) {
-                var u = o.div(i), c = (o.sub(u.mul(i)).toInt() >>> 0).toString(e);
-                if ((o = u).isZero()) return c + a;
-                for (;c.length < 6; ) c = "0" + c;
-                a = "" + c + a;
+            for (var i = l(f(e, 6), this.unsigned), s = this, o = ""; ;) {
+                var a = s.div(i), u = (s.sub(a.mul(i)).toInt() >>> 0).toString(e);
+                if ((s = a).isZero()) return u + o;
+                for (;u.length < 6; ) u = "0" + u;
+                o = "" + u + o;
             }
         }, B.getHighBits = function() {
             return this.high;
@@ -492,20 +492,20 @@ var osc = osc || {};
             return this.low >>> 0;
         }, B.getNumBitsAbs = function() {
             if (this.isNegative()) return this.eq(P) ? 64 : this.neg().getNumBitsAbs();
-            for (var e = 0 != this.high ? this.high : this.low, t = 31; t > 0 && 0 == (e & 1 << t); t--) ;
+            for (var e = 0 != this.high ? this.high : this.low, t = 31; 0 < t && 0 == (e & 1 << t); t--) ;
             return 0 != this.high ? t + 33 : t + 1;
         }, B.isZero = function() {
             return 0 === this.high && 0 === this.low;
         }, B.eqz = B.isZero, B.isNegative = function() {
             return !this.unsigned && this.high < 0;
         }, B.isPositive = function() {
-            return this.unsigned || this.high >= 0;
+            return this.unsigned || 0 <= this.high;
         }, B.isOdd = function() {
             return 1 == (1 & this.low);
         }, B.isEven = function() {
             return 0 == (1 & this.low);
         }, B.equals = function(e) {
-            return n(e) || (e = u(e)), (this.unsigned === e.unsigned || this.high >>> 31 != 1 || e.high >>> 31 != 1) && this.high === e.high && this.low === e.low;
+            return g(e) || (e = v(e)), (this.unsigned === e.unsigned || this.high >>> 31 != 1 || e.high >>> 31 != 1) && this.high === e.high && this.low === e.low;
         }, B.eq = B.equals, B.notEquals = function(e) {
             return !this.eq(e);
         }, B.neq = B.notEquals, B.ne = B.notEquals, B.lessThan = function(e) {
@@ -513,80 +513,80 @@ var osc = osc || {};
         }, B.lt = B.lessThan, B.lessThanOrEqual = function(e) {
             return this.comp(e) <= 0;
         }, B.lte = B.lessThanOrEqual, B.le = B.lessThanOrEqual, B.greaterThan = function(e) {
-            return this.comp(e) > 0;
+            return 0 < this.comp(e);
         }, B.gt = B.greaterThan, B.greaterThanOrEqual = function(e) {
-            return this.comp(e) >= 0;
+            return 0 <= this.comp(e);
         }, B.gte = B.greaterThanOrEqual, B.ge = B.greaterThanOrEqual, B.compare = function(e) {
-            if (n(e) || (e = u(e)), this.eq(e)) return 0;
+            if (g(e) || (e = v(e)), this.eq(e)) return 0;
             var t = this.isNegative(), r = e.isNegative();
             return t && !r ? -1 : !t && r ? 1 : this.unsigned ? e.high >>> 0 > this.high >>> 0 || e.high === this.high && e.low >>> 0 > this.low >>> 0 ? -1 : 1 : this.sub(e).isNegative() ? -1 : 1;
         }, B.comp = B.compare, B.negate = function() {
-            return !this.unsigned && this.eq(P) ? P : this.not().add(m);
+            return !this.unsigned && this.eq(P) ? P : this.not().add(d);
         }, B.neg = B.negate, B.add = function(e) {
-            n(e) || (e = u(e));
-            var t = this.high >>> 16, r = 65535 & this.high, i = this.low >>> 16, s = 65535 & this.low, a = e.high >>> 16, c = 65535 & e.high, h = e.low >>> 16, f = 0, d = 0, g = 0, l = 0;
-            return g += (l += s + (65535 & e.low)) >>> 16, d += (g += i + h) >>> 16, f += (d += r + c) >>> 16, 
-            f += t + a, o((g &= 65535) << 16 | (l &= 65535), (f &= 65535) << 16 | (d &= 65535), this.unsigned);
+            g(e) || (e = v(e));
+            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, a = e.low >>> 16, u = 0, c = 0, h = 0, f = 0;
+            return h += (f += i + (65535 & e.low)) >>> 16, c += (h += n + a) >>> 16, u += (c += r + o) >>> 16, 
+            u += t + s, p((h &= 65535) << 16 | (f &= 65535), (u &= 65535) << 16 | (c &= 65535), this.unsigned);
         }, B.subtract = function(e) {
-            return n(e) || (e = u(e)), this.add(e.neg());
+            return g(e) || (e = v(e)), this.add(e.neg());
         }, B.sub = B.subtract, B.multiply = function(e) {
-            if (this.isZero()) return y;
-            if (n(e) || (e = u(e)), c) return o(c.mul(this.low, this.high, e.low, e.high), c.get_high(), this.unsigned);
-            if (e.isZero()) return y;
-            if (this.eq(P)) return e.isOdd() ? P : y;
-            if (e.eq(P)) return this.isOdd() ? P : y;
+            if (this.isZero()) return m;
+            if (g(e) || (e = v(e)), y) return p(y.mul(this.low, this.high, e.low, e.high), y.get_high(), this.unsigned);
+            if (e.isZero()) return m;
+            if (this.eq(P)) return e.isOdd() ? P : m;
+            if (e.eq(P)) return this.isOdd() ? P : m;
             if (this.isNegative()) return e.isNegative() ? this.neg().mul(e.neg()) : this.neg().mul(e).neg();
             if (e.isNegative()) return this.mul(e.neg()).neg();
-            if (this.lt(v) && e.lt(v)) return s(this.toNumber() * e.toNumber(), this.unsigned);
-            var t = this.high >>> 16, r = 65535 & this.high, i = this.low >>> 16, a = 65535 & this.low, h = e.high >>> 16, f = 65535 & e.high, d = e.low >>> 16, g = 65535 & e.low, l = 0, p = 0, w = 0, m = 0;
-            return w += (m += a * g) >>> 16, p += (w += i * g) >>> 16, w &= 65535, p += (w += a * d) >>> 16, 
-            l += (p += r * g) >>> 16, p &= 65535, l += (p += i * d) >>> 16, p &= 65535, l += (p += a * f) >>> 16, 
-            l += t * g + r * d + i * f + a * h, o((w &= 65535) << 16 | (m &= 65535), (l &= 65535) << 16 | (p &= 65535), this.unsigned);
+            if (this.lt(w) && e.lt(w)) return l(this.toNumber() * e.toNumber(), this.unsigned);
+            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, a = e.low >>> 16, u = 65535 & e.low, c = 0, h = 0, f = 0, d = 0;
+            return f += (d += i * u) >>> 16, h += (f += n * u) >>> 16, f &= 65535, h += (f += i * a) >>> 16, 
+            c += (h += r * u) >>> 16, h &= 65535, c += (h += n * a) >>> 16, h &= 65535, c += (h += i * o) >>> 16, 
+            c += t * u + r * a + n * o + i * s, p((f &= 65535) << 16 | (d &= 65535), (c &= 65535) << 16 | (h &= 65535), this.unsigned);
         }, B.mul = B.multiply, B.divide = function(e) {
-            if (n(e) || (e = u(e)), e.isZero()) throw Error("division by zero");
-            if (c) return this.unsigned || -2147483648 !== this.high || -1 !== e.low || -1 !== e.high ? o((this.unsigned ? c.div_u : c.div_s)(this.low, this.high, e.low, e.high), c.get_high(), this.unsigned) : this;
-            if (this.isZero()) return this.unsigned ? w : y;
-            var t, r, i;
+            if (g(e) || (e = v(e)), e.isZero()) throw Error("division by zero");
+            if (y) return this.unsigned || -2147483648 !== this.high || -1 !== e.low || -1 !== e.high ? p((this.unsigned ? y.div_u : y.div_s)(this.low, this.high, e.low, e.high), y.get_high(), this.unsigned) : this;
+            if (this.isZero()) return this.unsigned ? c : m;
+            var t, r, n;
             if (this.unsigned) {
-                if (e.unsigned || (e = e.toUnsigned()), e.gt(this)) return w;
+                if (e.unsigned || (e = e.toUnsigned()), e.gt(this)) return c;
                 if (e.gt(this.shru(1))) return b;
-                i = w;
+                n = c;
             } else {
-                if (this.eq(P)) return e.eq(m) || e.eq(E) ? P : e.eq(P) ? m : (t = this.shr(1).div(e).shl(1)).eq(y) ? e.isNegative() ? m : E : (r = this.sub(e.mul(t)), 
-                i = t.add(r.div(e)));
-                if (e.eq(P)) return this.unsigned ? w : y;
+                if (this.eq(P)) return e.eq(d) || e.eq(E) ? P : e.eq(P) ? d : (t = this.shr(1).div(e).shl(1)).eq(m) ? e.isNegative() ? d : E : (r = this.sub(e.mul(t)), 
+                n = t.add(r.div(e)));
+                if (e.eq(P)) return this.unsigned ? c : m;
                 if (this.isNegative()) return e.isNegative() ? this.neg().div(e.neg()) : this.neg().div(e).neg();
                 if (e.isNegative()) return this.div(e.neg()).neg();
-                i = y;
+                n = m;
             }
             for (r = this; r.gte(e); ) {
                 t = Math.max(1, Math.floor(r.toNumber() / e.toNumber()));
-                for (var a = Math.ceil(Math.log(t) / Math.LN2), h = a <= 48 ? 1 : d(2, a - 48), f = s(t), g = f.mul(e); g.isNegative() || g.gt(r); ) g = (f = s(t -= h, this.unsigned)).mul(e);
-                f.isZero() && (f = m), i = i.add(f), r = r.sub(g);
+                for (var i = Math.ceil(Math.log(t) / Math.LN2), s = i <= 48 ? 1 : f(2, i - 48), o = l(t), a = o.mul(e); a.isNegative() || a.gt(r); ) a = (o = l(t -= s, this.unsigned)).mul(e);
+                o.isZero() && (o = d), n = n.add(o), r = r.sub(a);
             }
-            return i;
+            return n;
         }, B.div = B.divide, B.modulo = function(e) {
-            return n(e) || (e = u(e)), c ? o((this.unsigned ? c.rem_u : c.rem_s)(this.low, this.high, e.low, e.high), c.get_high(), this.unsigned) : this.sub(this.div(e).mul(e));
+            return g(e) || (e = v(e)), y ? p((this.unsigned ? y.rem_u : y.rem_s)(this.low, this.high, e.low, e.high), y.get_high(), this.unsigned) : this.sub(this.div(e).mul(e));
         }, B.mod = B.modulo, B.rem = B.modulo, B.not = function() {
-            return o(~this.low, ~this.high, this.unsigned);
+            return p(~this.low, ~this.high, this.unsigned);
         }, B.and = function(e) {
-            return n(e) || (e = u(e)), o(this.low & e.low, this.high & e.high, this.unsigned);
+            return g(e) || (e = v(e)), p(this.low & e.low, this.high & e.high, this.unsigned);
         }, B.or = function(e) {
-            return n(e) || (e = u(e)), o(this.low | e.low, this.high | e.high, this.unsigned);
+            return g(e) || (e = v(e)), p(this.low | e.low, this.high | e.high, this.unsigned);
         }, B.xor = function(e) {
-            return n(e) || (e = u(e)), o(this.low ^ e.low, this.high ^ e.high, this.unsigned);
+            return g(e) || (e = v(e)), p(this.low ^ e.low, this.high ^ e.high, this.unsigned);
         }, B.shiftLeft = function(e) {
-            return n(e) && (e = e.toInt()), 0 == (e &= 63) ? this : e < 32 ? o(this.low << e, this.high << e | this.low >>> 32 - e, this.unsigned) : o(0, this.low << e - 32, this.unsigned);
+            return g(e) && (e = e.toInt()), 0 == (e &= 63) ? this : e < 32 ? p(this.low << e, this.high << e | this.low >>> 32 - e, this.unsigned) : p(0, this.low << e - 32, this.unsigned);
         }, B.shl = B.shiftLeft, B.shiftRight = function(e) {
-            return n(e) && (e = e.toInt()), 0 == (e &= 63) ? this : e < 32 ? o(this.low >>> e | this.high << 32 - e, this.high >> e, this.unsigned) : o(this.high >> e - 32, this.high >= 0 ? 0 : -1, this.unsigned);
+            return g(e) && (e = e.toInt()), 0 == (e &= 63) ? this : e < 32 ? p(this.low >>> e | this.high << 32 - e, this.high >> e, this.unsigned) : p(this.high >> e - 32, 0 <= this.high ? 0 : -1, this.unsigned);
         }, B.shr = B.shiftRight, B.shiftRightUnsigned = function(e) {
-            if (n(e) && (e = e.toInt()), 0 == (e &= 63)) return this;
+            if (g(e) && (e = e.toInt()), 0 == (e &= 63)) return this;
             var t = this.high;
-            return e < 32 ? o(this.low >>> e | t << 32 - e, t >>> e, this.unsigned) : o(32 === e ? t : t >>> e - 32, 0, this.unsigned);
+            return e < 32 ? p(this.low >>> e | t << 32 - e, t >>> e, this.unsigned) : p(32 === e ? t : t >>> e - 32, 0, this.unsigned);
         }, B.shru = B.shiftRightUnsigned, B.shr_u = B.shiftRightUnsigned, B.toSigned = function() {
-            return this.unsigned ? o(this.low, this.high, !1) : this;
+            return this.unsigned ? p(this.low, this.high, !1) : this;
         }, B.toUnsigned = function() {
-            return this.unsigned ? this : o(this.low, this.high, !0);
+            return this.unsigned ? this : p(this.low, this.high, !0);
         }, B.toBytes = function(e) {
             return e ? this.toBytesLE() : this.toBytesBE();
         }, B.toBytesLE = function() {
@@ -595,88 +595,88 @@ var osc = osc || {};
         }, B.toBytesBE = function() {
             var e = this.high, t = this.low;
             return [ e >>> 24, e >>> 16 & 255, e >>> 8 & 255, 255 & e, t >>> 24, t >>> 16 & 255, t >>> 8 & 255, 255 & t ];
-        }, r.fromBytes = function(e, t, n) {
-            return n ? r.fromBytesLE(e, t) : r.fromBytesBE(e, t);
-        }, r.fromBytesLE = function(e, t) {
-            return new r(e[0] | e[1] << 8 | e[2] << 16 | e[3] << 24, e[4] | e[5] << 8 | e[6] << 16 | e[7] << 24, t);
-        }, r.fromBytesBE = function(e, t) {
-            return new r(e[4] << 24 | e[5] << 16 | e[6] << 8 | e[7], e[0] << 24 | e[1] << 16 | e[2] << 8 | e[3], t);
+        }, n.fromBytes = function(e, t, r) {
+            return r ? n.fromBytesLE(e, t) : n.fromBytesBE(e, t);
+        }, n.fromBytesLE = function(e, t) {
+            return new n(e[0] | e[1] << 8 | e[2] << 16 | e[3] << 24, e[4] | e[5] << 8 | e[6] << 16 | e[7] << 24, t);
+        }, n.fromBytesBE = function(e, t) {
+            return new n(e[4] << 24 | e[5] << 16 | e[6] << 8 | e[7], e[0] << 24 | e[1] << 16 | e[2] << 8 | e[3], t);
         };
     } ]);
-}), function(e, t) {
+}), function(t, r) {
     "use strict";
-    "object" == typeof exports ? (e.slip = exports, t(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(r) {
-        return e.slip = r, e.slip, t(r);
-    }) : (e.slip = {}, t(e.slip));
+    "object" == typeof exports ? (t.slip = exports, r(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(e) {
+        return t.slip = e, t.slip, r(e);
+    }) : (t.slip = {}, r(t.slip));
 }(this, function(e) {
     "use strict";
-    var t = e;
-    t.END = 192, t.ESC = 219, t.ESC_END = 220, t.ESC_ESC = 221, t.byteArray = function(e, t, r) {
+    var a = e;
+    a.END = 192, a.ESC = 219, a.ESC_END = 220, a.ESC_ESC = 221, a.byteArray = function(e, t, r) {
         return e instanceof ArrayBuffer ? new Uint8Array(e, t, r) : e;
-    }, t.expandByteArray = function(e) {
+    }, a.expandByteArray = function(e) {
         var t = new Uint8Array(2 * e.length);
         return t.set(e), t;
-    }, t.sliceByteArray = function(e, t, r) {
+    }, a.sliceByteArray = function(e, t, r) {
         var n = e.buffer.slice ? e.buffer.slice(t, r) : e.subarray(t, r);
         return new Uint8Array(n);
-    }, t.encode = function(e, r) {
-        (r = r || {}).bufferPadding = r.bufferPadding || 4;
-        var n = (e = t.byteArray(e, r.offset, r.byteLength)).length + r.bufferPadding + 3 & -4, i = new Uint8Array(n), s = 1;
-        i[0] = t.END;
-        for (var o = 0; o < e.length; o++) {
-            s > i.length - 3 && (i = t.expandByteArray(i));
-            var a = e[o];
-            a === t.END ? (i[s++] = t.ESC, a = t.ESC_END) : a === t.ESC && (i[s++] = t.ESC, 
-            a = t.ESC_ESC), i[s++] = a;
+    }, a.encode = function(e, t) {
+        (t = t || {}).bufferPadding = t.bufferPadding || 4;
+        var r = (e = a.byteArray(e, t.offset, t.byteLength)).length + t.bufferPadding + 3 & -4, n = new Uint8Array(r), i = 1;
+        n[0] = a.END;
+        for (var s = 0; s < e.length; s++) {
+            i > n.length - 3 && (n = a.expandByteArray(n));
+            var o = e[s];
+            o === a.END ? (n[i++] = a.ESC, o = a.ESC_END) : o === a.ESC && (n[i++] = a.ESC, 
+            o = a.ESC_ESC), n[i++] = o;
         }
-        return i[s] = t.END, t.sliceByteArray(i, 0, s + 1);
-    }, t.Decoder = function(e) {
+        return n[i] = a.END, a.sliceByteArray(n, 0, i + 1);
+    }, a.Decoder = function(e) {
         e = "function" != typeof e ? e || {} : {
             onMessage: e
         }, this.maxMessageSize = e.maxMessageSize || 10485760, this.bufferSize = e.bufferSize || 1024, 
         this.msgBuffer = new Uint8Array(this.bufferSize), this.msgBufferIdx = 0, this.onMessage = e.onMessage, 
         this.onError = e.onError, this.escape = !1;
     };
-    var r = t.Decoder.prototype;
-    return r.decode = function(e) {
-        var r;
-        e = t.byteArray(e);
-        for (var n = 0; n < e.length; n++) {
-            var i = e[n];
-            if (this.escape) i === t.ESC_ESC ? i = t.ESC : i === t.ESC_END && (i = t.END); else {
-                if (i === t.ESC) {
+    var t = a.Decoder.prototype;
+    return t.decode = function(e) {
+        var t;
+        e = a.byteArray(e);
+        for (var r = 0; r < e.length; r++) {
+            var n = e[r];
+            if (this.escape) n === a.ESC_ESC ? n = a.ESC : n === a.ESC_END && (n = a.END); else {
+                if (n === a.ESC) {
                     this.escape = !0;
                     continue;
                 }
-                if (i === t.END) {
-                    r = this.handleEnd();
+                if (n === a.END) {
+                    t = this.handleEnd();
                     continue;
                 }
             }
-            this.addByte(i) || this.handleMessageMaxError();
+            this.addByte(n) || this.handleMessageMaxError();
         }
-        return r;
-    }, r.handleMessageMaxError = function() {
+        return t;
+    }, t.handleMessageMaxError = function() {
         this.onError && this.onError(this.msgBuffer.subarray(0), "The message is too large; the maximum message size is " + this.maxMessageSize / 1024 + "KB. Use a larger maxMessageSize if necessary."), 
         this.msgBufferIdx = 0, this.escape = !1;
-    }, r.addByte = function(e) {
-        return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = t.expandByteArray(this.msgBuffer)), 
+    }, t.addByte = function(e) {
+        return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = a.expandByteArray(this.msgBuffer)), 
         this.msgBuffer[this.msgBufferIdx++] = e, this.escape = !1, this.msgBuffer.length < this.maxMessageSize;
-    }, r.handleEnd = function() {
+    }, t.handleEnd = function() {
         if (0 !== this.msgBufferIdx) {
-            var e = t.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
+            var e = a.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
             return this.onMessage && this.onMessage(e), this.msgBufferIdx = 0, e;
         }
-    }, t;
+    }, a;
 }), function(e) {
     "use strict";
     function t() {}
     var r = t.prototype, n = e.EventEmitter;
-    function i(e, t) {
+    function s(e, t) {
         for (var r = e.length; r--; ) if (e[r].listener === t) return r;
         return -1;
     }
-    function s(e) {
+    function i(e) {
         return function() {
             return this[e].apply(this, arguments);
         };
@@ -696,27 +696,27 @@ var osc = osc || {};
         if (!function e(t) {
             return "function" == typeof t || t instanceof RegExp || !(!t || "object" != typeof t) && e(t.listener);
         }(t)) throw new TypeError("listener must be a function");
-        var r, n = this.getListenersAsObject(e), s = "object" == typeof t;
-        for (r in n) n.hasOwnProperty(r) && -1 === i(n[r], t) && n[r].push(s ? t : {
+        var r, n = this.getListenersAsObject(e), i = "object" == typeof t;
+        for (r in n) n.hasOwnProperty(r) && -1 === s(n[r], t) && n[r].push(i ? t : {
             listener: t,
             once: !1
         });
         return this;
-    }, r.on = s("addListener"), r.addOnceListener = function(e, t) {
+    }, r.on = i("addListener"), r.addOnceListener = function(e, t) {
         return this.addListener(e, {
             listener: t,
             once: !0
         });
-    }, r.once = s("addOnceListener"), r.defineEvent = function(e) {
+    }, r.once = i("addOnceListener"), r.defineEvent = function(e) {
         return this.getListeners(e), this;
     }, r.defineEvents = function(e) {
         for (var t = 0; t < e.length; t += 1) this.defineEvent(e[t]);
         return this;
     }, r.removeListener = function(e, t) {
-        var r, n, s = this.getListenersAsObject(e);
-        for (n in s) s.hasOwnProperty(n) && -1 !== (r = i(s[n], t)) && s[n].splice(r, 1);
+        var r, n, i = this.getListenersAsObject(e);
+        for (n in i) i.hasOwnProperty(n) && -1 !== (r = s(i[n], t)) && i[n].splice(r, 1);
         return this;
-    }, r.off = s("removeListener"), r.addListeners = function(e, t) {
+    }, r.off = i("removeListener"), r.addListeners = function(e, t) {
         return this.manipulateListeners(!1, e, t);
     }, r.removeListeners = function(e, t) {
         return this.manipulateListeners(!0, e, t);
@@ -728,12 +728,12 @@ var osc = osc || {};
         var t, r = typeof e, n = this._getEvents();
         if ("string" === r) delete n[e]; else if (e instanceof RegExp) for (t in n) n.hasOwnProperty(t) && e.test(t) && delete n[t]; else delete this._events;
         return this;
-    }, r.removeAllListeners = s("removeEvent"), r.emitEvent = function(e, t) {
+    }, r.removeAllListeners = i("removeEvent"), r.emitEvent = function(e, t) {
         var r, n, i, s, o = this.getListenersAsObject(e);
         for (s in o) if (o.hasOwnProperty(s)) for (r = o[s].slice(0), i = 0; i < r.length; i++) !0 === (n = r[i]).once && this.removeListener(e, n.listener), 
         n.listener.apply(this, t || []) === this._getOnceReturnValue() && this.removeListener(e, n.listener);
         return this;
-    }, r.trigger = s("emitEvent"), r.emit = function(e) {
+    }, r.trigger = i("emitEvent"), r.emit = function(e) {
         var t = Array.prototype.slice.call(arguments, 1);
         return this.emitEvent(e, t);
     }, r.setOnceReturnValue = function(e) {
@@ -854,21 +854,21 @@ osc = osc || require("../osc.js");
     };
     var e = osc.WebSocketPort.prototype = Object.create(osc.Port.prototype);
     e.constructor = osc.WebSocketPort, e.open = function() {
-        (!this.socket || this.socket.readyState > 1) && (this.socket = new osc.WebSocket(this.options.url)), 
+        (!this.socket || 1 < this.socket.readyState) && (this.socket = new osc.WebSocket(this.options.url)), 
         osc.WebSocketPort.setupSocketForBinary(this.socket);
         var e = this;
         this.socket.onopen = function() {
             e.emit("open", e.socket);
         };
     }, e.listen = function() {
-        var e = this;
-        this.socket.onmessage = function(t) {
-            e.emit("data", t.data, t);
-        }, this.socket.onerror = function(t) {
-            e.emit("error", t);
-        }, this.socket.onclose = function(t) {
-            e.emit("close", t);
-        }, e.emit("ready");
+        var t = this;
+        this.socket.onmessage = function(e) {
+            t.emit("data", e.data, e);
+        }, this.socket.onerror = function(e) {
+            t.emit("error", e);
+        }, this.socket.onclose = function(e) {
+            t.emit("close", e);
+        }, t.emit("ready");
     }, e.sendRaw = function(e) {
         this.socket && 1 === this.socket.readyState ? this.socket.send(e) : osc.fireClosedPortSendError(this);
     }, e.close = function(e, t) {

--- a/dist/osc-chromeapp.min.js
+++ b/dist/osc-chromeapp.min.js
@@ -126,7 +126,7 @@ var osc = osc || {};
     }, osc.timeTag = function(t, e) {
         t = t || 0;
         var r = (e = e || Date.now()) / 1e3, n = Math.floor(r), i = r - n, s = Math.floor(t), o = i + (t - s);
-        if (o > 1) {
+        if (1 < o) {
             var a = Math.floor(o);
             s += a, o = o - a;
         }
@@ -360,127 +360,127 @@ var osc = osc || {};
 }(), function(t, e) {
     "object" == typeof exports && "object" == typeof module ? module.exports = e() : "function" == typeof define && define.amd ? define([], e) : "object" == typeof exports ? exports.Long = e() : t.Long = e();
 }("undefined" != typeof self ? self : this, function() {
-    return function(t) {
-        function e(n) {
-            if (r[n]) return r[n].exports;
-            var i = r[n] = {
-                i: n,
+    return function(r) {
+        function n(t) {
+            if (i[t]) return i[t].exports;
+            var e = i[t] = {
+                i: t,
                 l: !1,
                 exports: {}
             };
-            return t[n].call(i.exports, i, i.exports, e), i.l = !0, i.exports;
+            return r[t].call(e.exports, e, e.exports, n), e.l = !0, e.exports;
         }
-        var r = {};
-        return e.m = t, e.c = r, e.d = function(t, r, n) {
-            e.o(t, r) || Object.defineProperty(t, r, {
+        var i = {};
+        return n.m = r, n.c = i, n.d = function(t, e, r) {
+            n.o(t, e) || Object.defineProperty(t, e, {
                 configurable: !1,
                 enumerable: !0,
-                get: n
+                get: r
             });
-        }, e.n = function(t) {
-            var r = t && t.__esModule ? function() {
+        }, n.n = function(t) {
+            var e = t && t.__esModule ? function() {
                 return t.default;
             } : function() {
                 return t;
             };
-            return e.d(r, "a", r), r;
-        }, e.o = function(t, e) {
+            return n.d(e, "a", e), e;
+        }, n.o = function(t, e) {
             return Object.prototype.hasOwnProperty.call(t, e);
-        }, e.p = "", e(e.s = 0);
+        }, n.p = "", n(n.s = 0);
     }([ function(t, e) {
-        function r(t, e, r) {
+        function n(t, e, r) {
             this.low = 0 | t, this.high = 0 | e, this.unsigned = !!r;
         }
-        function n(t) {
+        function l(t) {
             return !0 === (t && t.__isLong__);
         }
-        function i(t, e) {
+        function r(t, e) {
             var r, n, i;
-            return e ? (i = 0 <= (t >>>= 0) && t < 256) && (n = f[t]) ? n : (r = o(t, (0 | t) < 0 ? -1 : 0, !0), 
-            i && (f[t] = r), r) : (i = -128 <= (t |= 0) && t < 128) && (n = h[t]) ? n : (r = o(t, t < 0 ? -1 : 0, !1), 
-            i && (h[t] = r), r);
+            return e ? (i = 0 <= (t >>>= 0) && t < 256) && (n = o[t]) ? n : (r = p(t, (0 | t) < 0 ? -1 : 0, !0), 
+            i && (o[t] = r), r) : (i = -128 <= (t |= 0) && t < 128) && (n = s[t]) ? n : (r = p(t, t < 0 ? -1 : 0, !1), 
+            i && (s[t] = r), r);
         }
-        function s(t, e) {
-            if (isNaN(t)) return e ? y : v;
+        function g(t, e) {
+            if (isNaN(t)) return e ? u : w;
             if (e) {
-                if (t < 0) return y;
-                if (t >= g) return P;
+                if (t < 0) return u;
+                if (a <= t) return P;
             } else {
-                if (t <= -p) return A;
-                if (t + 1 >= p) return S;
+                if (t <= -c) return A;
+                if (c <= t + 1) return S;
             }
-            return t < 0 ? s(-t, e).neg() : o(t % l | 0, t / l | 0, e);
+            return t < 0 ? g(-t, e).neg() : p(t % i | 0, t / i | 0, e);
         }
-        function o(t, e, n) {
-            return new r(t, e, n);
+        function p(t, e, r) {
+            return new n(t, e, r);
         }
-        function a(t, e, r) {
+        function h(t, e, r) {
             if (0 === t.length) throw Error("empty string");
-            if ("NaN" === t || "Infinity" === t || "+Infinity" === t || "-Infinity" === t) return v;
+            if ("NaN" === t || "Infinity" === t || "+Infinity" === t || "-Infinity" === t) return w;
             if ("number" == typeof e ? (r = e, e = !1) : e = !!e, (r = r || 10) < 2 || 36 < r) throw RangeError("radix");
             var n;
-            if ((n = t.indexOf("-")) > 0) throw Error("interior hyphen");
-            if (0 === n) return a(t.substring(1), e, r).neg();
-            for (var i = s(d(r, 8)), o = v, c = 0; c < t.length; c += 8) {
-                var u = Math.min(8, t.length - c), h = parseInt(t.substring(c, c + u), r);
-                if (u < 8) {
-                    var f = s(d(r, u));
-                    o = o.mul(f).add(s(h));
-                } else o = (o = o.mul(i)).add(s(h));
+            if (0 < (n = t.indexOf("-"))) throw Error("interior hyphen");
+            if (0 === n) return h(t.substring(1), e, r).neg();
+            for (var i = g(f(r, 8)), s = w, o = 0; o < t.length; o += 8) {
+                var a = Math.min(8, t.length - o), c = parseInt(t.substring(o, o + a), r);
+                if (a < 8) {
+                    var u = g(f(r, a));
+                    s = s.mul(u).add(g(c));
+                } else s = (s = s.mul(i)).add(g(c));
             }
-            return o.unsigned = e, o;
+            return s.unsigned = e, s;
         }
-        function c(t, e) {
-            return "number" == typeof t ? s(t, e) : "string" == typeof t ? a(t, e) : o(t.low, t.high, "boolean" == typeof e ? e : t.unsigned);
+        function m(t, e) {
+            return "number" == typeof t ? g(t, e) : "string" == typeof t ? h(t, e) : p(t.low, t.high, "boolean" == typeof e ? e : t.unsigned);
         }
-        t.exports = r;
-        var u = null;
+        t.exports = n;
+        var v = null;
         try {
-            u = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array([ 0, 97, 115, 109, 1, 0, 0, 0, 1, 13, 2, 96, 0, 1, 127, 96, 4, 127, 127, 127, 127, 1, 127, 3, 7, 6, 0, 1, 1, 1, 1, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 50, 6, 3, 109, 117, 108, 0, 1, 5, 100, 105, 118, 95, 115, 0, 2, 5, 100, 105, 118, 95, 117, 0, 3, 5, 114, 101, 109, 95, 115, 0, 4, 5, 114, 101, 109, 95, 117, 0, 5, 8, 103, 101, 116, 95, 104, 105, 103, 104, 0, 0, 10, 191, 1, 6, 4, 0, 35, 0, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 126, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 127, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 128, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 129, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 130, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11 ])), {}).exports;
+            v = new WebAssembly.Instance(new WebAssembly.Module(new Uint8Array([ 0, 97, 115, 109, 1, 0, 0, 0, 1, 13, 2, 96, 0, 1, 127, 96, 4, 127, 127, 127, 127, 1, 127, 3, 7, 6, 0, 1, 1, 1, 1, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 50, 6, 3, 109, 117, 108, 0, 1, 5, 100, 105, 118, 95, 115, 0, 2, 5, 100, 105, 118, 95, 117, 0, 3, 5, 114, 101, 109, 95, 115, 0, 4, 5, 114, 101, 109, 95, 117, 0, 5, 8, 103, 101, 116, 95, 104, 105, 103, 104, 0, 0, 10, 191, 1, 6, 4, 0, 35, 0, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 126, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 127, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 128, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 129, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11, 36, 1, 1, 126, 32, 0, 173, 32, 1, 173, 66, 32, 134, 132, 32, 2, 173, 32, 3, 173, 66, 32, 134, 132, 130, 34, 4, 66, 32, 135, 167, 36, 0, 32, 4, 167, 11 ])), {}).exports;
         } catch (t) {}
-        r.prototype.__isLong__, Object.defineProperty(r.prototype, "__isLong__", {
+        Object.defineProperty(n.prototype, "__isLong__", {
             value: !0
-        }), r.isLong = n;
-        var h = {}, f = {};
-        r.fromInt = i, r.fromNumber = s, r.fromBits = o;
-        var d = Math.pow;
-        r.fromString = a, r.fromValue = c;
-        var l = 4294967296, g = l * l, p = g / 2, m = i(1 << 24), v = i(0);
-        r.ZERO = v;
-        var y = i(0, !0);
-        r.UZERO = y;
-        var w = i(1);
-        r.ONE = w;
-        var b = i(1, !0);
-        r.UONE = b;
-        var E = i(-1);
-        r.NEG_ONE = E;
-        var S = o(-1, 2147483647, !1);
-        r.MAX_VALUE = S;
-        var P = o(-1, -1, !0);
-        r.MAX_UNSIGNED_VALUE = P;
-        var A = o(0, -2147483648, !1);
-        r.MIN_VALUE = A;
-        var I = r.prototype;
+        }), n.isLong = l;
+        var s = {}, o = {};
+        n.fromInt = r, n.fromNumber = g, n.fromBits = p;
+        var f = Math.pow;
+        n.fromString = h, n.fromValue = m;
+        var i = 4294967296, a = i * i, c = a / 2, y = r(1 << 24), w = r(0);
+        n.ZERO = w;
+        var u = r(0, !0);
+        n.UZERO = u;
+        var d = r(1);
+        n.ONE = d;
+        var b = r(1, !0);
+        n.UONE = b;
+        var E = r(-1);
+        n.NEG_ONE = E;
+        var S = p(-1, 2147483647, !1);
+        n.MAX_VALUE = S;
+        var P = p(-1, -1, !0);
+        n.MAX_UNSIGNED_VALUE = P;
+        var A = p(0, -2147483648, !1);
+        n.MIN_VALUE = A;
+        var I = n.prototype;
         I.toInt = function() {
             return this.unsigned ? this.low >>> 0 : this.low;
         }, I.toNumber = function() {
-            return this.unsigned ? (this.high >>> 0) * l + (this.low >>> 0) : this.high * l + (this.low >>> 0);
+            return this.unsigned ? (this.high >>> 0) * i + (this.low >>> 0) : this.high * i + (this.low >>> 0);
         }, I.toString = function(t) {
             if ((t = t || 10) < 2 || 36 < t) throw RangeError("radix");
             if (this.isZero()) return "0";
             if (this.isNegative()) {
                 if (this.eq(A)) {
-                    var e = s(t), r = this.div(e), n = r.mul(e).sub(this);
+                    var e = g(t), r = this.div(e), n = r.mul(e).sub(this);
                     return r.toString(t) + n.toInt().toString(t);
                 }
                 return "-" + this.neg().toString(t);
             }
-            for (var i = s(d(t, 6), this.unsigned), o = this, a = ""; ;) {
-                var c = o.div(i), u = (o.sub(c.mul(i)).toInt() >>> 0).toString(t);
-                if ((o = c).isZero()) return u + a;
-                for (;u.length < 6; ) u = "0" + u;
-                a = "" + u + a;
+            for (var i = g(f(t, 6), this.unsigned), s = this, o = ""; ;) {
+                var a = s.div(i), c = (s.sub(a.mul(i)).toInt() >>> 0).toString(t);
+                if ((s = a).isZero()) return c + o;
+                for (;c.length < 6; ) c = "0" + c;
+                o = "" + c + o;
             }
         }, I.getHighBits = function() {
             return this.high;
@@ -492,20 +492,20 @@ var osc = osc || {};
             return this.low >>> 0;
         }, I.getNumBitsAbs = function() {
             if (this.isNegative()) return this.eq(A) ? 64 : this.neg().getNumBitsAbs();
-            for (var t = 0 != this.high ? this.high : this.low, e = 31; e > 0 && 0 == (t & 1 << e); e--) ;
+            for (var t = 0 != this.high ? this.high : this.low, e = 31; 0 < e && 0 == (t & 1 << e); e--) ;
             return 0 != this.high ? e + 33 : e + 1;
         }, I.isZero = function() {
             return 0 === this.high && 0 === this.low;
         }, I.eqz = I.isZero, I.isNegative = function() {
             return !this.unsigned && this.high < 0;
         }, I.isPositive = function() {
-            return this.unsigned || this.high >= 0;
+            return this.unsigned || 0 <= this.high;
         }, I.isOdd = function() {
             return 1 == (1 & this.low);
         }, I.isEven = function() {
             return 0 == (1 & this.low);
         }, I.equals = function(t) {
-            return n(t) || (t = c(t)), (this.unsigned === t.unsigned || this.high >>> 31 != 1 || t.high >>> 31 != 1) && this.high === t.high && this.low === t.low;
+            return l(t) || (t = m(t)), (this.unsigned === t.unsigned || this.high >>> 31 != 1 || t.high >>> 31 != 1) && this.high === t.high && this.low === t.low;
         }, I.eq = I.equals, I.notEquals = function(t) {
             return !this.eq(t);
         }, I.neq = I.notEquals, I.ne = I.notEquals, I.lessThan = function(t) {
@@ -513,80 +513,80 @@ var osc = osc || {};
         }, I.lt = I.lessThan, I.lessThanOrEqual = function(t) {
             return this.comp(t) <= 0;
         }, I.lte = I.lessThanOrEqual, I.le = I.lessThanOrEqual, I.greaterThan = function(t) {
-            return this.comp(t) > 0;
+            return 0 < this.comp(t);
         }, I.gt = I.greaterThan, I.greaterThanOrEqual = function(t) {
-            return this.comp(t) >= 0;
+            return 0 <= this.comp(t);
         }, I.gte = I.greaterThanOrEqual, I.ge = I.greaterThanOrEqual, I.compare = function(t) {
-            if (n(t) || (t = c(t)), this.eq(t)) return 0;
+            if (l(t) || (t = m(t)), this.eq(t)) return 0;
             var e = this.isNegative(), r = t.isNegative();
             return e && !r ? -1 : !e && r ? 1 : this.unsigned ? t.high >>> 0 > this.high >>> 0 || t.high === this.high && t.low >>> 0 > this.low >>> 0 ? -1 : 1 : this.sub(t).isNegative() ? -1 : 1;
         }, I.comp = I.compare, I.negate = function() {
-            return !this.unsigned && this.eq(A) ? A : this.not().add(w);
+            return !this.unsigned && this.eq(A) ? A : this.not().add(d);
         }, I.neg = I.negate, I.add = function(t) {
-            n(t) || (t = c(t));
-            var e = this.high >>> 16, r = 65535 & this.high, i = this.low >>> 16, s = 65535 & this.low, a = t.high >>> 16, u = 65535 & t.high, h = t.low >>> 16, f = 0, d = 0, l = 0, g = 0;
-            return l += (g += s + (65535 & t.low)) >>> 16, d += (l += i + h) >>> 16, f += (d += r + u) >>> 16, 
-            f += e + a, o((l &= 65535) << 16 | (g &= 65535), (f &= 65535) << 16 | (d &= 65535), this.unsigned);
+            l(t) || (t = m(t));
+            var e = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = t.high >>> 16, o = 65535 & t.high, a = t.low >>> 16, c = 0, u = 0, h = 0, f = 0;
+            return h += (f += i + (65535 & t.low)) >>> 16, u += (h += n + a) >>> 16, c += (u += r + o) >>> 16, 
+            c += e + s, p((h &= 65535) << 16 | (f &= 65535), (c &= 65535) << 16 | (u &= 65535), this.unsigned);
         }, I.subtract = function(t) {
-            return n(t) || (t = c(t)), this.add(t.neg());
+            return l(t) || (t = m(t)), this.add(t.neg());
         }, I.sub = I.subtract, I.multiply = function(t) {
-            if (this.isZero()) return v;
-            if (n(t) || (t = c(t)), u) return o(u.mul(this.low, this.high, t.low, t.high), u.get_high(), this.unsigned);
-            if (t.isZero()) return v;
-            if (this.eq(A)) return t.isOdd() ? A : v;
-            if (t.eq(A)) return this.isOdd() ? A : v;
+            if (this.isZero()) return w;
+            if (l(t) || (t = m(t)), v) return p(v.mul(this.low, this.high, t.low, t.high), v.get_high(), this.unsigned);
+            if (t.isZero()) return w;
+            if (this.eq(A)) return t.isOdd() ? A : w;
+            if (t.eq(A)) return this.isOdd() ? A : w;
             if (this.isNegative()) return t.isNegative() ? this.neg().mul(t.neg()) : this.neg().mul(t).neg();
             if (t.isNegative()) return this.mul(t.neg()).neg();
-            if (this.lt(m) && t.lt(m)) return s(this.toNumber() * t.toNumber(), this.unsigned);
-            var e = this.high >>> 16, r = 65535 & this.high, i = this.low >>> 16, a = 65535 & this.low, h = t.high >>> 16, f = 65535 & t.high, d = t.low >>> 16, l = 65535 & t.low, g = 0, p = 0, y = 0, w = 0;
-            return y += (w += a * l) >>> 16, p += (y += i * l) >>> 16, y &= 65535, p += (y += a * d) >>> 16, 
-            g += (p += r * l) >>> 16, p &= 65535, g += (p += i * d) >>> 16, p &= 65535, g += (p += a * f) >>> 16, 
-            g += e * l + r * d + i * f + a * h, o((y &= 65535) << 16 | (w &= 65535), (g &= 65535) << 16 | (p &= 65535), this.unsigned);
+            if (this.lt(y) && t.lt(y)) return g(this.toNumber() * t.toNumber(), this.unsigned);
+            var e = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = t.high >>> 16, o = 65535 & t.high, a = t.low >>> 16, c = 65535 & t.low, u = 0, h = 0, f = 0, d = 0;
+            return f += (d += i * c) >>> 16, h += (f += n * c) >>> 16, f &= 65535, h += (f += i * a) >>> 16, 
+            u += (h += r * c) >>> 16, h &= 65535, u += (h += n * a) >>> 16, h &= 65535, u += (h += i * o) >>> 16, 
+            u += e * c + r * a + n * o + i * s, p((f &= 65535) << 16 | (d &= 65535), (u &= 65535) << 16 | (h &= 65535), this.unsigned);
         }, I.mul = I.multiply, I.divide = function(t) {
-            if (n(t) || (t = c(t)), t.isZero()) throw Error("division by zero");
-            if (u) return this.unsigned || -2147483648 !== this.high || -1 !== t.low || -1 !== t.high ? o((this.unsigned ? u.div_u : u.div_s)(this.low, this.high, t.low, t.high), u.get_high(), this.unsigned) : this;
-            if (this.isZero()) return this.unsigned ? y : v;
-            var e, r, i;
+            if (l(t) || (t = m(t)), t.isZero()) throw Error("division by zero");
+            if (v) return this.unsigned || -2147483648 !== this.high || -1 !== t.low || -1 !== t.high ? p((this.unsigned ? v.div_u : v.div_s)(this.low, this.high, t.low, t.high), v.get_high(), this.unsigned) : this;
+            if (this.isZero()) return this.unsigned ? u : w;
+            var e, r, n;
             if (this.unsigned) {
-                if (t.unsigned || (t = t.toUnsigned()), t.gt(this)) return y;
+                if (t.unsigned || (t = t.toUnsigned()), t.gt(this)) return u;
                 if (t.gt(this.shru(1))) return b;
-                i = y;
+                n = u;
             } else {
-                if (this.eq(A)) return t.eq(w) || t.eq(E) ? A : t.eq(A) ? w : (e = this.shr(1).div(t).shl(1)).eq(v) ? t.isNegative() ? w : E : (r = this.sub(t.mul(e)), 
-                i = e.add(r.div(t)));
-                if (t.eq(A)) return this.unsigned ? y : v;
+                if (this.eq(A)) return t.eq(d) || t.eq(E) ? A : t.eq(A) ? d : (e = this.shr(1).div(t).shl(1)).eq(w) ? t.isNegative() ? d : E : (r = this.sub(t.mul(e)), 
+                n = e.add(r.div(t)));
+                if (t.eq(A)) return this.unsigned ? u : w;
                 if (this.isNegative()) return t.isNegative() ? this.neg().div(t.neg()) : this.neg().div(t).neg();
                 if (t.isNegative()) return this.div(t.neg()).neg();
-                i = v;
+                n = w;
             }
             for (r = this; r.gte(t); ) {
                 e = Math.max(1, Math.floor(r.toNumber() / t.toNumber()));
-                for (var a = Math.ceil(Math.log(e) / Math.LN2), h = a <= 48 ? 1 : d(2, a - 48), f = s(e), l = f.mul(t); l.isNegative() || l.gt(r); ) l = (f = s(e -= h, this.unsigned)).mul(t);
-                f.isZero() && (f = w), i = i.add(f), r = r.sub(l);
+                for (var i = Math.ceil(Math.log(e) / Math.LN2), s = i <= 48 ? 1 : f(2, i - 48), o = g(e), a = o.mul(t); a.isNegative() || a.gt(r); ) a = (o = g(e -= s, this.unsigned)).mul(t);
+                o.isZero() && (o = d), n = n.add(o), r = r.sub(a);
             }
-            return i;
+            return n;
         }, I.div = I.divide, I.modulo = function(t) {
-            return n(t) || (t = c(t)), u ? o((this.unsigned ? u.rem_u : u.rem_s)(this.low, this.high, t.low, t.high), u.get_high(), this.unsigned) : this.sub(this.div(t).mul(t));
+            return l(t) || (t = m(t)), v ? p((this.unsigned ? v.rem_u : v.rem_s)(this.low, this.high, t.low, t.high), v.get_high(), this.unsigned) : this.sub(this.div(t).mul(t));
         }, I.mod = I.modulo, I.rem = I.modulo, I.not = function() {
-            return o(~this.low, ~this.high, this.unsigned);
+            return p(~this.low, ~this.high, this.unsigned);
         }, I.and = function(t) {
-            return n(t) || (t = c(t)), o(this.low & t.low, this.high & t.high, this.unsigned);
+            return l(t) || (t = m(t)), p(this.low & t.low, this.high & t.high, this.unsigned);
         }, I.or = function(t) {
-            return n(t) || (t = c(t)), o(this.low | t.low, this.high | t.high, this.unsigned);
+            return l(t) || (t = m(t)), p(this.low | t.low, this.high | t.high, this.unsigned);
         }, I.xor = function(t) {
-            return n(t) || (t = c(t)), o(this.low ^ t.low, this.high ^ t.high, this.unsigned);
+            return l(t) || (t = m(t)), p(this.low ^ t.low, this.high ^ t.high, this.unsigned);
         }, I.shiftLeft = function(t) {
-            return n(t) && (t = t.toInt()), 0 == (t &= 63) ? this : t < 32 ? o(this.low << t, this.high << t | this.low >>> 32 - t, this.unsigned) : o(0, this.low << t - 32, this.unsigned);
+            return l(t) && (t = t.toInt()), 0 == (t &= 63) ? this : t < 32 ? p(this.low << t, this.high << t | this.low >>> 32 - t, this.unsigned) : p(0, this.low << t - 32, this.unsigned);
         }, I.shl = I.shiftLeft, I.shiftRight = function(t) {
-            return n(t) && (t = t.toInt()), 0 == (t &= 63) ? this : t < 32 ? o(this.low >>> t | this.high << 32 - t, this.high >> t, this.unsigned) : o(this.high >> t - 32, this.high >= 0 ? 0 : -1, this.unsigned);
+            return l(t) && (t = t.toInt()), 0 == (t &= 63) ? this : t < 32 ? p(this.low >>> t | this.high << 32 - t, this.high >> t, this.unsigned) : p(this.high >> t - 32, 0 <= this.high ? 0 : -1, this.unsigned);
         }, I.shr = I.shiftRight, I.shiftRightUnsigned = function(t) {
-            if (n(t) && (t = t.toInt()), 0 == (t &= 63)) return this;
+            if (l(t) && (t = t.toInt()), 0 == (t &= 63)) return this;
             var e = this.high;
-            return t < 32 ? o(this.low >>> t | e << 32 - t, e >>> t, this.unsigned) : o(32 === t ? e : e >>> t - 32, 0, this.unsigned);
+            return t < 32 ? p(this.low >>> t | e << 32 - t, e >>> t, this.unsigned) : p(32 === t ? e : e >>> t - 32, 0, this.unsigned);
         }, I.shru = I.shiftRightUnsigned, I.shr_u = I.shiftRightUnsigned, I.toSigned = function() {
-            return this.unsigned ? o(this.low, this.high, !1) : this;
+            return this.unsigned ? p(this.low, this.high, !1) : this;
         }, I.toUnsigned = function() {
-            return this.unsigned ? this : o(this.low, this.high, !0);
+            return this.unsigned ? this : p(this.low, this.high, !0);
         }, I.toBytes = function(t) {
             return t ? this.toBytesLE() : this.toBytesBE();
         }, I.toBytesLE = function() {
@@ -595,88 +595,88 @@ var osc = osc || {};
         }, I.toBytesBE = function() {
             var t = this.high, e = this.low;
             return [ t >>> 24, t >>> 16 & 255, t >>> 8 & 255, 255 & t, e >>> 24, e >>> 16 & 255, e >>> 8 & 255, 255 & e ];
-        }, r.fromBytes = function(t, e, n) {
-            return n ? r.fromBytesLE(t, e) : r.fromBytesBE(t, e);
-        }, r.fromBytesLE = function(t, e) {
-            return new r(t[0] | t[1] << 8 | t[2] << 16 | t[3] << 24, t[4] | t[5] << 8 | t[6] << 16 | t[7] << 24, e);
-        }, r.fromBytesBE = function(t, e) {
-            return new r(t[4] << 24 | t[5] << 16 | t[6] << 8 | t[7], t[0] << 24 | t[1] << 16 | t[2] << 8 | t[3], e);
+        }, n.fromBytes = function(t, e, r) {
+            return r ? n.fromBytesLE(t, e) : n.fromBytesBE(t, e);
+        }, n.fromBytesLE = function(t, e) {
+            return new n(t[0] | t[1] << 8 | t[2] << 16 | t[3] << 24, t[4] | t[5] << 8 | t[6] << 16 | t[7] << 24, e);
+        }, n.fromBytesBE = function(t, e) {
+            return new n(t[4] << 24 | t[5] << 16 | t[6] << 8 | t[7], t[0] << 24 | t[1] << 16 | t[2] << 8 | t[3], e);
         };
     } ]);
-}), function(t, e) {
+}), function(e, r) {
     "use strict";
-    "object" == typeof exports ? (t.slip = exports, e(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(r) {
-        return t.slip = r, t.slip, e(r);
-    }) : (t.slip = {}, e(t.slip));
+    "object" == typeof exports ? (e.slip = exports, r(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(t) {
+        return e.slip = t, e.slip, r(t);
+    }) : (e.slip = {}, r(e.slip));
 }(this, function(t) {
     "use strict";
-    var e = t;
-    e.END = 192, e.ESC = 219, e.ESC_END = 220, e.ESC_ESC = 221, e.byteArray = function(t, e, r) {
+    var a = t;
+    a.END = 192, a.ESC = 219, a.ESC_END = 220, a.ESC_ESC = 221, a.byteArray = function(t, e, r) {
         return t instanceof ArrayBuffer ? new Uint8Array(t, e, r) : t;
-    }, e.expandByteArray = function(t) {
+    }, a.expandByteArray = function(t) {
         var e = new Uint8Array(2 * t.length);
         return e.set(t), e;
-    }, e.sliceByteArray = function(t, e, r) {
+    }, a.sliceByteArray = function(t, e, r) {
         var n = t.buffer.slice ? t.buffer.slice(e, r) : t.subarray(e, r);
         return new Uint8Array(n);
-    }, e.encode = function(t, r) {
-        (r = r || {}).bufferPadding = r.bufferPadding || 4;
-        var n = (t = e.byteArray(t, r.offset, r.byteLength)).length + r.bufferPadding + 3 & -4, i = new Uint8Array(n), s = 1;
-        i[0] = e.END;
-        for (var o = 0; o < t.length; o++) {
-            s > i.length - 3 && (i = e.expandByteArray(i));
-            var a = t[o];
-            a === e.END ? (i[s++] = e.ESC, a = e.ESC_END) : a === e.ESC && (i[s++] = e.ESC, 
-            a = e.ESC_ESC), i[s++] = a;
+    }, a.encode = function(t, e) {
+        (e = e || {}).bufferPadding = e.bufferPadding || 4;
+        var r = (t = a.byteArray(t, e.offset, e.byteLength)).length + e.bufferPadding + 3 & -4, n = new Uint8Array(r), i = 1;
+        n[0] = a.END;
+        for (var s = 0; s < t.length; s++) {
+            i > n.length - 3 && (n = a.expandByteArray(n));
+            var o = t[s];
+            o === a.END ? (n[i++] = a.ESC, o = a.ESC_END) : o === a.ESC && (n[i++] = a.ESC, 
+            o = a.ESC_ESC), n[i++] = o;
         }
-        return i[s] = e.END, e.sliceByteArray(i, 0, s + 1);
-    }, e.Decoder = function(t) {
+        return n[i] = a.END, a.sliceByteArray(n, 0, i + 1);
+    }, a.Decoder = function(t) {
         t = "function" != typeof t ? t || {} : {
             onMessage: t
         }, this.maxMessageSize = t.maxMessageSize || 10485760, this.bufferSize = t.bufferSize || 1024, 
         this.msgBuffer = new Uint8Array(this.bufferSize), this.msgBufferIdx = 0, this.onMessage = t.onMessage, 
         this.onError = t.onError, this.escape = !1;
     };
-    var r = e.Decoder.prototype;
-    return r.decode = function(t) {
-        var r;
-        t = e.byteArray(t);
-        for (var n = 0; n < t.length; n++) {
-            var i = t[n];
-            if (this.escape) i === e.ESC_ESC ? i = e.ESC : i === e.ESC_END && (i = e.END); else {
-                if (i === e.ESC) {
+    var e = a.Decoder.prototype;
+    return e.decode = function(t) {
+        var e;
+        t = a.byteArray(t);
+        for (var r = 0; r < t.length; r++) {
+            var n = t[r];
+            if (this.escape) n === a.ESC_ESC ? n = a.ESC : n === a.ESC_END && (n = a.END); else {
+                if (n === a.ESC) {
                     this.escape = !0;
                     continue;
                 }
-                if (i === e.END) {
-                    r = this.handleEnd();
+                if (n === a.END) {
+                    e = this.handleEnd();
                     continue;
                 }
             }
-            this.addByte(i) || this.handleMessageMaxError();
+            this.addByte(n) || this.handleMessageMaxError();
         }
-        return r;
-    }, r.handleMessageMaxError = function() {
+        return e;
+    }, e.handleMessageMaxError = function() {
         this.onError && this.onError(this.msgBuffer.subarray(0), "The message is too large; the maximum message size is " + this.maxMessageSize / 1024 + "KB. Use a larger maxMessageSize if necessary."), 
         this.msgBufferIdx = 0, this.escape = !1;
-    }, r.addByte = function(t) {
-        return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = e.expandByteArray(this.msgBuffer)), 
+    }, e.addByte = function(t) {
+        return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = a.expandByteArray(this.msgBuffer)), 
         this.msgBuffer[this.msgBufferIdx++] = t, this.escape = !1, this.msgBuffer.length < this.maxMessageSize;
-    }, r.handleEnd = function() {
+    }, e.handleEnd = function() {
         if (0 !== this.msgBufferIdx) {
-            var t = e.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
+            var t = a.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
             return this.onMessage && this.onMessage(t), this.msgBufferIdx = 0, t;
         }
-    }, e;
+    }, a;
 }), function(t) {
     "use strict";
     function e() {}
     var r = e.prototype, n = t.EventEmitter;
-    function i(t, e) {
+    function s(t, e) {
         for (var r = t.length; r--; ) if (t[r].listener === e) return r;
         return -1;
     }
-    function s(t) {
+    function i(t) {
         return function() {
             return this[t].apply(this, arguments);
         };
@@ -696,27 +696,27 @@ var osc = osc || {};
         if (!function t(e) {
             return "function" == typeof e || e instanceof RegExp || !(!e || "object" != typeof e) && t(e.listener);
         }(e)) throw new TypeError("listener must be a function");
-        var r, n = this.getListenersAsObject(t), s = "object" == typeof e;
-        for (r in n) n.hasOwnProperty(r) && -1 === i(n[r], e) && n[r].push(s ? e : {
+        var r, n = this.getListenersAsObject(t), i = "object" == typeof e;
+        for (r in n) n.hasOwnProperty(r) && -1 === s(n[r], e) && n[r].push(i ? e : {
             listener: e,
             once: !1
         });
         return this;
-    }, r.on = s("addListener"), r.addOnceListener = function(t, e) {
+    }, r.on = i("addListener"), r.addOnceListener = function(t, e) {
         return this.addListener(t, {
             listener: e,
             once: !0
         });
-    }, r.once = s("addOnceListener"), r.defineEvent = function(t) {
+    }, r.once = i("addOnceListener"), r.defineEvent = function(t) {
         return this.getListeners(t), this;
     }, r.defineEvents = function(t) {
         for (var e = 0; e < t.length; e += 1) this.defineEvent(t[e]);
         return this;
     }, r.removeListener = function(t, e) {
-        var r, n, s = this.getListenersAsObject(t);
-        for (n in s) s.hasOwnProperty(n) && -1 !== (r = i(s[n], e)) && s[n].splice(r, 1);
+        var r, n, i = this.getListenersAsObject(t);
+        for (n in i) i.hasOwnProperty(n) && -1 !== (r = s(i[n], e)) && i[n].splice(r, 1);
         return this;
-    }, r.off = s("removeListener"), r.addListeners = function(t, e) {
+    }, r.off = i("removeListener"), r.addListeners = function(t, e) {
         return this.manipulateListeners(!1, t, e);
     }, r.removeListeners = function(t, e) {
         return this.manipulateListeners(!0, t, e);
@@ -728,12 +728,12 @@ var osc = osc || {};
         var e, r = typeof t, n = this._getEvents();
         if ("string" === r) delete n[t]; else if (t instanceof RegExp) for (e in n) n.hasOwnProperty(e) && t.test(e) && delete n[e]; else delete this._events;
         return this;
-    }, r.removeAllListeners = s("removeEvent"), r.emitEvent = function(t, e) {
+    }, r.removeAllListeners = i("removeEvent"), r.emitEvent = function(t, e) {
         var r, n, i, s, o = this.getListenersAsObject(t);
         for (s in o) if (o.hasOwnProperty(s)) for (r = o[s].slice(0), i = 0; i < r.length; i++) !0 === (n = r[i]).once && this.removeListener(t, n.listener), 
         n.listener.apply(this, e || []) === this._getOnceReturnValue() && this.removeListener(t, n.listener);
         return this;
-    }, r.trigger = s("emitEvent"), r.emit = function(t) {
+    }, r.trigger = i("emitEvent"), r.emit = function(t) {
         var e = Array.prototype.slice.call(arguments, 1);
         return this.emitEvent(t, e);
     }, r.setOnceReturnValue = function(t) {
@@ -854,21 +854,21 @@ osc = osc || require("../osc.js");
     };
     var t = osc.WebSocketPort.prototype = Object.create(osc.Port.prototype);
     t.constructor = osc.WebSocketPort, t.open = function() {
-        (!this.socket || this.socket.readyState > 1) && (this.socket = new osc.WebSocket(this.options.url)), 
+        (!this.socket || 1 < this.socket.readyState) && (this.socket = new osc.WebSocket(this.options.url)), 
         osc.WebSocketPort.setupSocketForBinary(this.socket);
         var t = this;
         this.socket.onopen = function() {
             t.emit("open", t.socket);
         };
     }, t.listen = function() {
-        var t = this;
-        this.socket.onmessage = function(e) {
-            t.emit("data", e.data, e);
-        }, this.socket.onerror = function(e) {
-            t.emit("error", e);
-        }, this.socket.onclose = function(e) {
-            t.emit("close", e);
-        }, t.emit("ready");
+        var e = this;
+        this.socket.onmessage = function(t) {
+            e.emit("data", t.data, t);
+        }, this.socket.onerror = function(t) {
+            e.emit("error", t);
+        }, this.socket.onclose = function(t) {
+            e.emit("close", t);
+        }, e.emit("ready");
     }, t.sendRaw = function(t) {
         this.socket && 1 === this.socket.readyState ? this.socket.send(t) : osc.fireClosedPortSendError(this);
     }, t.close = function(t, e) {
@@ -882,12 +882,12 @@ osc = osc || {};
 
 !function() {
     "use strict";
-    osc.listenToTransport = function(t, e, r) {
-        e.onReceive.addListener(function(e) {
-            e[r] === t[r] && t.emit("data", e.data, e);
-        }), e.onReceiveError.addListener(function(e) {
-            t.emit("error", e);
-        }), t.emit("ready");
+    osc.listenToTransport = function(e, t, r) {
+        t.onReceive.addListener(function(t) {
+            t[r] === e[r] && e.emit("data", t.data, t);
+        }), t.onReceiveError.addListener(function(t) {
+            e.emit("error", t);
+        }), e.emit("ready");
     }, osc.emitNetworkError = function(t, e) {
         t.emit("error", "There was an error while opening the UDP socket connection. Result code: " + e);
     }, osc.SerialPort = function(t) {
@@ -896,26 +896,26 @@ osc = osc || {};
     };
     var t = osc.SerialPort.prototype = Object.create(osc.SLIPPort.prototype);
     t.constructor = osc.SerialPort, t.open = function() {
-        var t = this, e = {
-            bitrate: t.options.bitrate
+        var e = this, t = {
+            bitrate: e.options.bitrate
         };
-        chrome.serial.connect(this.options.devicePath, e, function(e) {
-            t.connectionId = e.connectionId, t.emit("open", e);
+        chrome.serial.connect(this.options.devicePath, t, function(t) {
+            e.connectionId = t.connectionId, e.emit("open", t);
         });
     }, t.listen = function() {
         osc.listenToTransport(this, chrome.serial, "connectionId");
     }, t.sendRaw = function(t) {
         if (this.connectionId) {
-            var e = this;
-            chrome.serial.send(this.connectionId, t.buffer, function(t, r) {
-                r && e.emit("error", r + ". Total bytes sent: " + t);
+            var r = this;
+            chrome.serial.send(this.connectionId, t.buffer, function(t, e) {
+                e && r.emit("error", e + ". Total bytes sent: " + t);
             });
         } else osc.fireClosedPortSendError(this);
     }, t.close = function() {
         if (this.connectionId) {
-            var t = this;
-            chrome.serial.disconnect(this.connectionId, function(e) {
-                e && t.emit("close");
+            var e = this;
+            chrome.serial.disconnect(this.connectionId, function(t) {
+                t && e.emit("close");
             });
         }
     }, osc.UDPPort = function(t) {
@@ -936,20 +936,20 @@ osc = osc || {};
             });
         }
     }, t.bindSocket = function() {
-        var t = this, e = this.options;
-        void 0 !== e.broadcast && chrome.sockets.udp.setBroadcast(this.socketId, e.broadcast, function(e) {
-            e < 0 && t.emit("error", new Error("An error occurred while setting the socket's broadcast flag. Result code: " + e));
-        }), void 0 !== e.multicastTTL && chrome.sockets.udp.setMulticastTimeToLive(this.socketId, e.multicastTTL, function(e) {
-            e < 0 && t.emit("error", new Error("An error occurred while setting the socket's multicast time to live flag. Result code: " + e));
-        }), chrome.sockets.udp.bind(this.socketId, e.localAddress, e.localPort, function(e) {
-            e > 0 ? osc.emitNetworkError(t, e) : t.emit("open", e);
+        var e = this, t = this.options;
+        void 0 !== t.broadcast && chrome.sockets.udp.setBroadcast(this.socketId, t.broadcast, function(t) {
+            t < 0 && e.emit("error", new Error("An error occurred while setting the socket's broadcast flag. Result code: " + t));
+        }), void 0 !== t.multicastTTL && chrome.sockets.udp.setMulticastTimeToLive(this.socketId, t.multicastTTL, function(t) {
+            t < 0 && e.emit("error", new Error("An error occurred while setting the socket's multicast time to live flag. Result code: " + t));
+        }), chrome.sockets.udp.bind(this.socketId, t.localAddress, t.localPort, function(t) {
+            0 < t ? osc.emitNetworkError(e, t) : e.emit("open", t);
         });
     }, t.listen = function() {
         var t = this.options;
         osc.listenToTransport(this, chrome.sockets.udp, "socketId"), t.multicastMembership && ("string" == typeof t.multicastMembership && (t.multicastMembership = [ t.multicastMembership ]), 
-        t.multicastMembership.forEach(function(t) {
-            chrome.sockets.udp.joinGroup(this.socketId, t, function(e) {
-                e < 0 && this.emit("error", new Error("There was an error while trying to join the multicast group " + t + ". Result code: " + e));
+        t.multicastMembership.forEach(function(e) {
+            chrome.sockets.udp.joinGroup(this.socketId, e, function(t) {
+                t < 0 && this.emit("error", new Error("There was an error while trying to join the multicast group " + e + ". Result code: " + t));
             });
         }));
     }, t.sendRaw = function(t, e, r) {
@@ -957,7 +957,7 @@ osc = osc || {};
             var n = this.options, i = this;
             e = e || n.remoteAddress, r = void 0 !== r ? r : n.remotePort, chrome.sockets.udp.send(this.socketId, t.buffer, e, r, function(t) {
                 t || i.emit("error", "There was an unknown error while trying to send a UDP message. Have you declared the appropriate udp send permissions in your application's manifest file?"), 
-                t.resultCode > 0 && osc.emitNetworkError(i, t.resultCode);
+                0 < t.resultCode && osc.emitNetworkError(i, t.resultCode);
             });
         } else osc.fireClosedPortSendError(this);
     }, t.close = function() {

--- a/dist/osc-module.min.js
+++ b/dist/osc-module.min.js
@@ -1,39 +1,39 @@
 /*! osc.js 2.2.2, Copyright 2018 Colin Clark | github.com/colinbdclark/osc.js */
 
 
-!function(e, t) {
-    "object" == typeof exports ? (e.osc = exports, t(exports, require("slip"), require("EventEmitter"), require("long"))) : "function" == typeof define && define.amd ? define([ "exports", "slip", "EventEmitter", "long" ], function(r, n, i, a) {
-        return e.osc = r, e.osc, t(r, n, i, a);
-    }) : (e.osc = {}, t(e.osc, slip, EventEmitter));
-}(this, function(e, t, r, n) {
-    var i = i || {};
+!function(i, a) {
+    "object" == typeof exports ? (i.osc = exports, a(exports, require("slip"), require("EventEmitter"), require("long"))) : "function" == typeof define && define.amd ? define([ "exports", "slip", "EventEmitter", "long" ], function(e, t, r, n) {
+        return i.osc = e, i.osc, a(e, t, r, n);
+    }) : (i.osc = {}, a(i.osc, slip, EventEmitter));
+}(this, function(e, i, t, r) {
+    var l = l || {};
     !function() {
         "use strict";
-        i.SECS_70YRS = 2208988800, i.TWO_32 = 4294967296, i.defaults = {
+        l.SECS_70YRS = 2208988800, l.TWO_32 = 4294967296, l.defaults = {
             metadata: !1,
             unpackSingleArgs: !0
-        }, i.isCommonJS = !("undefined" == typeof module || !module.exports), i.isNode = i.isCommonJS && "undefined" == typeof window, 
-        i.isElectron = !("undefined" == typeof process || !process.versions || !process.versions.electron), 
-        i.isBufferEnv = i.isNode || i.isElectron, i.isArray = function(e) {
+        }, l.isCommonJS = !("undefined" == typeof module || !module.exports), l.isNode = l.isCommonJS && "undefined" == typeof window, 
+        l.isElectron = !("undefined" == typeof process || !process.versions || !process.versions.electron), 
+        l.isBufferEnv = l.isNode || l.isElectron, l.isArray = function(e) {
             return e && "[object Array]" === Object.prototype.toString.call(e);
-        }, i.isTypedArrayView = function(e) {
+        }, l.isTypedArrayView = function(e) {
             return e.buffer && e.buffer instanceof ArrayBuffer;
-        }, i.isBuffer = function(e) {
-            return i.isBufferEnv && e instanceof Buffer;
-        }, i.Long = void 0 !== n ? n : i.isNode ? require("long") : void 0, i.dataView = function(e, t, r) {
+        }, l.isBuffer = function(e) {
+            return l.isBufferEnv && e instanceof Buffer;
+        }, l.Long = void 0 !== r ? r : l.isNode ? require("long") : void 0, l.dataView = function(e, t, r) {
             return e.buffer ? new DataView(e.buffer, t, r) : e instanceof ArrayBuffer ? new DataView(e, t, r) : new DataView(new Uint8Array(e), t, r);
-        }, i.byteArray = function(e) {
+        }, l.byteArray = function(e) {
             if (e instanceof Uint8Array) return e;
             var t = e.buffer ? e.buffer : e;
             if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
             return new Uint8Array(t);
-        }, i.nativeBuffer = function(e) {
-            return i.isBufferEnv ? i.isBuffer(e) ? e : new Buffer(e.buffer ? e : new Uint8Array(e)) : i.isTypedArrayView(e) ? e : new Uint8Array(e);
-        }, i.copyByteArray = function(e, t, r) {
-            if (i.isTypedArrayView(e) && i.isTypedArrayView(t)) t.set(e, r); else for (var n = void 0 === r ? 0 : r, a = Math.min(t.length - r, e.length), o = 0, s = n; o < a; o++, 
-            s++) t[s] = e[o];
+        }, l.nativeBuffer = function(e) {
+            return l.isBufferEnv ? l.isBuffer(e) ? e : new Buffer(e.buffer ? e : new Uint8Array(e)) : l.isTypedArrayView(e) ? e : new Uint8Array(e);
+        }, l.copyByteArray = function(e, t, r) {
+            if (l.isTypedArrayView(e) && l.isTypedArrayView(t)) t.set(e, r); else for (var n = void 0 === r ? 0 : r, i = Math.min(t.length - r, e.length), a = 0, o = n; a < i; a++, 
+            o++) t[o] = e[a];
             return t;
-        }, i.readString = function(e, t) {
+        }, l.readString = function(e, t) {
             for (var r = [], n = t.idx; n < e.byteLength; n++) {
                 var i = e.getUint8(n);
                 if (0 === i) {
@@ -43,62 +43,62 @@
                 r.push(i);
             }
             return n = n + 3 & -4, t.idx = n, String.fromCharCode.apply(null, r);
-        }, i.writeString = function(e) {
+        }, l.writeString = function(e) {
             for (var t = e + "\0", r = t.length, n = new Uint8Array(r + 3 & -4), i = 0; i < t.length; i++) {
                 var a = t.charCodeAt(i);
                 n[i] = a;
             }
             return n;
-        }, i.readPrimitive = function(e, t, r, n) {
+        }, l.readPrimitive = function(e, t, r, n) {
             var i = e[t](n.idx, !1);
             return n.idx += r, i;
-        }, i.writePrimitive = function(e, t, r, n, i) {
+        }, l.writePrimitive = function(e, t, r, n, i) {
             var a;
             return i = void 0 === i ? 0 : i, t ? a = new Uint8Array(t.buffer) : (a = new Uint8Array(n), 
             t = new DataView(a.buffer)), t[r](i, e, !1), a;
-        }, i.readInt32 = function(e, t) {
-            return i.readPrimitive(e, "getInt32", 4, t);
-        }, i.writeInt32 = function(e, t, r) {
-            return i.writePrimitive(e, t, "setInt32", 4, r);
-        }, i.readInt64 = function(e, t) {
-            var r = i.readPrimitive(e, "getInt32", 4, t), n = i.readPrimitive(e, "getInt32", 4, t);
-            return i.Long ? new i.Long(n, r) : {
+        }, l.readInt32 = function(e, t) {
+            return l.readPrimitive(e, "getInt32", 4, t);
+        }, l.writeInt32 = function(e, t, r) {
+            return l.writePrimitive(e, t, "setInt32", 4, r);
+        }, l.readInt64 = function(e, t) {
+            var r = l.readPrimitive(e, "getInt32", 4, t), n = l.readPrimitive(e, "getInt32", 4, t);
+            return l.Long ? new l.Long(n, r) : {
                 high: r,
                 low: n,
                 unsigned: !1
             };
-        }, i.writeInt64 = function(e, t, r) {
+        }, l.writeInt64 = function(e, t, r) {
             var n = new Uint8Array(8);
-            return n.set(i.writePrimitive(e.high, t, "setInt32", 4, r), 0), n.set(i.writePrimitive(e.low, t, "setInt32", 4, r + 4), 4), 
+            return n.set(l.writePrimitive(e.high, t, "setInt32", 4, r), 0), n.set(l.writePrimitive(e.low, t, "setInt32", 4, r + 4), 4), 
             n;
-        }, i.readFloat32 = function(e, t) {
-            return i.readPrimitive(e, "getFloat32", 4, t);
-        }, i.writeFloat32 = function(e, t, r) {
-            return i.writePrimitive(e, t, "setFloat32", 4, r);
-        }, i.readFloat64 = function(e, t) {
-            return i.readPrimitive(e, "getFloat64", 8, t);
-        }, i.writeFloat64 = function(e, t, r) {
-            return i.writePrimitive(e, t, "setFloat64", 8, r);
-        }, i.readChar32 = function(e, t) {
-            var r = i.readPrimitive(e, "getUint32", 4, t);
+        }, l.readFloat32 = function(e, t) {
+            return l.readPrimitive(e, "getFloat32", 4, t);
+        }, l.writeFloat32 = function(e, t, r) {
+            return l.writePrimitive(e, t, "setFloat32", 4, r);
+        }, l.readFloat64 = function(e, t) {
+            return l.readPrimitive(e, "getFloat64", 8, t);
+        }, l.writeFloat64 = function(e, t, r) {
+            return l.writePrimitive(e, t, "setFloat64", 8, r);
+        }, l.readChar32 = function(e, t) {
+            var r = l.readPrimitive(e, "getUint32", 4, t);
             return String.fromCharCode(r);
-        }, i.writeChar32 = function(e, t, r) {
+        }, l.writeChar32 = function(e, t, r) {
             var n = e.charCodeAt(0);
-            if (!(void 0 === n || n < -1)) return i.writePrimitive(n, t, "setUint32", 4, r);
-        }, i.readBlob = function(e, t) {
-            var r = i.readInt32(e, t), n = r + 3 & -4, a = new Uint8Array(e.buffer, t.idx, r);
-            return t.idx += n, a;
-        }, i.writeBlob = function(e) {
-            var t = (e = i.byteArray(e)).byteLength, r = new Uint8Array((t + 3 & -4) + 4), n = new DataView(r.buffer);
-            return i.writeInt32(t, n), r.set(e, 4), r;
-        }, i.readMIDIBytes = function(e, t) {
+            if (!(void 0 === n || n < -1)) return l.writePrimitive(n, t, "setUint32", 4, r);
+        }, l.readBlob = function(e, t) {
+            var r = l.readInt32(e, t), n = r + 3 & -4, i = new Uint8Array(e.buffer, t.idx, r);
+            return t.idx += n, i;
+        }, l.writeBlob = function(e) {
+            var t = (e = l.byteArray(e)).byteLength, r = new Uint8Array((t + 3 & -4) + 4), n = new DataView(r.buffer);
+            return l.writeInt32(t, n), r.set(e, 4), r;
+        }, l.readMIDIBytes = function(e, t) {
             var r = new Uint8Array(e.buffer, t.idx, 4);
             return t.idx += 4, r;
-        }, i.writeMIDIBytes = function(e) {
-            e = i.byteArray(e);
+        }, l.writeMIDIBytes = function(e) {
+            e = l.byteArray(e);
             var t = new Uint8Array(4);
             return t.set(e), t;
-        }, i.readColor = function(e, t) {
+        }, l.readColor = function(e, t) {
             var r = new Uint8Array(e.buffer, t.idx, 4), n = r[3] / 255;
             return t.idx += 4, {
                 r: r[0],
@@ -106,170 +106,170 @@
                 b: r[2],
                 a: n
             };
-        }, i.writeColor = function(e) {
+        }, l.writeColor = function(e) {
             var t = Math.round(255 * e.a);
             return new Uint8Array([ e.r, e.g, e.b, t ]);
-        }, i.readTrue = function() {
+        }, l.readTrue = function() {
             return !0;
-        }, i.readFalse = function() {
+        }, l.readFalse = function() {
             return !1;
-        }, i.readNull = function() {
+        }, l.readNull = function() {
             return null;
-        }, i.readImpulse = function() {
+        }, l.readImpulse = function() {
             return 1;
-        }, i.readTimeTag = function(e, t) {
-            var r = i.readPrimitive(e, "getUint32", 4, t), n = i.readPrimitive(e, "getUint32", 4, t);
+        }, l.readTimeTag = function(e, t) {
+            var r = l.readPrimitive(e, "getUint32", 4, t), n = l.readPrimitive(e, "getUint32", 4, t);
             return {
                 raw: [ r, n ],
-                native: 0 === r && 1 === n ? Date.now() : i.ntpToJSTime(r, n)
+                native: 0 === r && 1 === n ? Date.now() : l.ntpToJSTime(r, n)
             };
-        }, i.writeTimeTag = function(e) {
-            var t = e.raw ? e.raw : i.jsToNTPTime(e.native), r = new Uint8Array(8), n = new DataView(r.buffer);
-            return i.writeInt32(t[0], n, 0), i.writeInt32(t[1], n, 4), r;
-        }, i.timeTag = function(e, t) {
+        }, l.writeTimeTag = function(e) {
+            var t = e.raw ? e.raw : l.jsToNTPTime(e.native), r = new Uint8Array(8), n = new DataView(r.buffer);
+            return l.writeInt32(t[0], n, 0), l.writeInt32(t[1], n, 4), r;
+        }, l.timeTag = function(e, t) {
             e = e || 0;
-            var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), a = r - n, o = Math.floor(e), s = a + (e - o);
-            if (s > 1) {
-                var u = Math.floor(s);
-                o += u, s = s - u;
+            var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), i = r - n, a = Math.floor(e), o = i + (e - a);
+            if (1 < o) {
+                var s = Math.floor(o);
+                a += s, o = o - s;
             }
             return {
-                raw: [ n + o + i.SECS_70YRS, Math.round(i.TWO_32 * s) ]
+                raw: [ n + a + l.SECS_70YRS, Math.round(l.TWO_32 * o) ]
             };
-        }, i.ntpToJSTime = function(e, t) {
-            return 1e3 * (e - i.SECS_70YRS + t / i.TWO_32);
-        }, i.jsToNTPTime = function(e) {
+        }, l.ntpToJSTime = function(e, t) {
+            return 1e3 * (e - l.SECS_70YRS + t / l.TWO_32);
+        }, l.jsToNTPTime = function(e) {
             var t = e / 1e3, r = Math.floor(t), n = t - r;
-            return [ r + i.SECS_70YRS, Math.round(i.TWO_32 * n) ];
-        }, i.readArguments = function(e, t, r) {
-            var n = i.readString(e, r);
+            return [ r + l.SECS_70YRS, Math.round(l.TWO_32 * n) ];
+        }, l.readArguments = function(e, t, r) {
+            var n = l.readString(e, r);
             if (0 !== n.indexOf(",")) throw new Error("A malformed type tag string was found while reading the arguments of an OSC message. String was: " + n, " at offset: " + r.idx);
-            var a = n.substring(1).split(""), o = [];
-            return i.readArgumentsIntoArray(o, a, n, e, t, r), o;
-        }, i.readArgument = function(e, t, r, n, a) {
-            var o = i.argumentTypes[e];
-            if (!o) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + t);
-            var s = o.reader, u = i[s](r, a);
-            return n.metadata && (u = {
+            var i = n.substring(1).split(""), a = [];
+            return l.readArgumentsIntoArray(a, i, n, e, t, r), a;
+        }, l.readArgument = function(e, t, r, n, i) {
+            var a = l.argumentTypes[e];
+            if (!a) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + t);
+            var o = a.reader, s = l[o](r, i);
+            return n.metadata && (s = {
                 type: e,
-                value: u
-            }), u;
-        }, i.readArgumentsIntoArray = function(e, t, r, n, a, o) {
-            for (var s = 0; s < t.length; ) {
-                var u, c = t[s];
-                if ("[" === c) {
-                    var d = t.slice(s + 1), f = d.indexOf("]");
-                    if (f < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + r);
-                    var l = d.slice(0, f);
-                    u = i.readArgumentsIntoArray([], l, r, n, a, o), s += f + 2;
-                } else u = i.readArgument(c, r, n, a, o), s++;
-                e.push(u);
+                value: s
+            }), s;
+        }, l.readArgumentsIntoArray = function(e, t, r, n, i, a) {
+            for (var o = 0; o < t.length; ) {
+                var s, u = t[o];
+                if ("[" === u) {
+                    var c = t.slice(o + 1), d = c.indexOf("]");
+                    if (d < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + r);
+                    var f = c.slice(0, d);
+                    s = l.readArgumentsIntoArray([], f, r, n, i, a), o += d + 2;
+                } else s = l.readArgument(u, r, n, i, a), o++;
+                e.push(s);
             }
             return e;
-        }, i.writeArguments = function(e, t) {
-            var r = i.collectArguments(e, t);
-            return i.joinParts(r);
-        }, i.joinParts = function(e) {
-            for (var t = new Uint8Array(e.byteLength), r = e.parts, n = 0, a = 0; a < r.length; a++) {
-                var o = r[a];
-                i.copyByteArray(o, t, n), n += o.length;
+        }, l.writeArguments = function(e, t) {
+            var r = l.collectArguments(e, t);
+            return l.joinParts(r);
+        }, l.joinParts = function(e) {
+            for (var t = new Uint8Array(e.byteLength), r = e.parts, n = 0, i = 0; i < r.length; i++) {
+                var a = r[i];
+                l.copyByteArray(a, t, n), n += a.length;
             }
             return t;
-        }, i.addDataPart = function(e, t) {
+        }, l.addDataPart = function(e, t) {
             t.parts.push(e), t.byteLength += e.length;
-        }, i.writeArrayArguments = function(e, t) {
+        }, l.writeArrayArguments = function(e, t) {
             for (var r = "[", n = 0; n < e.length; n++) {
-                var a = e[n];
-                r += i.writeArgument(a, t);
+                var i = e[n];
+                r += l.writeArgument(i, t);
             }
             return r += "]";
-        }, i.writeArgument = function(e, t) {
-            if (i.isArray(e)) return i.writeArrayArguments(e, t);
-            var r = e.type, n = i.argumentTypes[r].writer;
+        }, l.writeArgument = function(e, t) {
+            if (l.isArray(e)) return l.writeArrayArguments(e, t);
+            var r = e.type, n = l.argumentTypes[r].writer;
             if (n) {
-                var a = i[n](e.value);
-                i.addDataPart(a, t);
+                var i = l[n](e.value);
+                l.addDataPart(i, t);
             }
             return e.type;
-        }, i.collectArguments = function(e, t, r) {
-            i.isArray(e) || (e = void 0 === e ? [] : [ e ]), r = r || {
+        }, l.collectArguments = function(e, t, r) {
+            l.isArray(e) || (e = void 0 === e ? [] : [ e ]), r = r || {
                 byteLength: 0,
                 parts: []
-            }, t.metadata || (e = i.annotateArguments(e));
-            for (var n = ",", a = r.parts.length, o = 0; o < e.length; o++) {
-                var s = e[o];
-                n += i.writeArgument(s, r);
+            }, t.metadata || (e = l.annotateArguments(e));
+            for (var n = ",", i = r.parts.length, a = 0; a < e.length; a++) {
+                var o = e[a];
+                n += l.writeArgument(o, r);
             }
-            var u = i.writeString(n);
-            return r.byteLength += u.byteLength, r.parts.splice(a, 0, u), r;
-        }, i.readMessage = function(e, t, r) {
-            t = t || i.defaults;
-            var n = i.dataView(e, e.byteOffset, e.byteLength);
+            var s = l.writeString(n);
+            return r.byteLength += s.byteLength, r.parts.splice(i, 0, s), r;
+        }, l.readMessage = function(e, t, r) {
+            t = t || l.defaults;
+            var n = l.dataView(e, e.byteOffset, e.byteLength);
             r = r || {
                 idx: 0
             };
-            var a = i.readString(n, r);
-            return i.readMessageContents(a, n, t, r);
-        }, i.readMessageContents = function(e, t, r, n) {
+            var i = l.readString(n, r);
+            return l.readMessageContents(i, n, t, r);
+        }, l.readMessageContents = function(e, t, r, n) {
             if (0 !== e.indexOf("/")) throw new Error("A malformed OSC address was found while reading an OSC message. String was: " + e);
-            var a = i.readArguments(t, r, n);
+            var i = l.readArguments(t, r, n);
             return {
                 address: e,
-                args: 1 === a.length && r.unpackSingleArgs ? a[0] : a
+                args: 1 === i.length && r.unpackSingleArgs ? i[0] : i
             };
-        }, i.collectMessageParts = function(e, t, r) {
+        }, l.collectMessageParts = function(e, t, r) {
             return r = r || {
                 byteLength: 0,
                 parts: []
-            }, i.addDataPart(i.writeString(e.address), r), i.collectArguments(e.args, t, r);
-        }, i.writeMessage = function(e, t) {
-            if (t = t || i.defaults, !i.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
-            var r = i.collectMessageParts(e, t);
-            return i.joinParts(r);
-        }, i.isValidMessage = function(e) {
+            }, l.addDataPart(l.writeString(e.address), r), l.collectArguments(e.args, t, r);
+        }, l.writeMessage = function(e, t) {
+            if (t = t || l.defaults, !l.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
+            var r = l.collectMessageParts(e, t);
+            return l.joinParts(r);
+        }, l.isValidMessage = function(e) {
             return e.address && 0 === e.address.indexOf("/");
-        }, i.readBundle = function(e, t, r) {
-            return i.readPacket(e, t, r);
-        }, i.collectBundlePackets = function(e, t, r) {
+        }, l.readBundle = function(e, t, r) {
+            return l.readPacket(e, t, r);
+        }, l.collectBundlePackets = function(e, t, r) {
             r = r || {
                 byteLength: 0,
                 parts: []
-            }, i.addDataPart(i.writeString("#bundle"), r), i.addDataPart(i.writeTimeTag(e.timeTag), r);
+            }, l.addDataPart(l.writeString("#bundle"), r), l.addDataPart(l.writeTimeTag(e.timeTag), r);
             for (var n = 0; n < e.packets.length; n++) {
-                var a = e.packets[n], o = (a.address ? i.collectMessageParts : i.collectBundlePackets)(a, t);
-                r.byteLength += o.byteLength, i.addDataPart(i.writeInt32(o.byteLength), r), r.parts = r.parts.concat(o.parts);
+                var i = e.packets[n], a = (i.address ? l.collectMessageParts : l.collectBundlePackets)(i, t);
+                r.byteLength += a.byteLength, l.addDataPart(l.writeInt32(a.byteLength), r), r.parts = r.parts.concat(a.parts);
             }
             return r;
-        }, i.writeBundle = function(e, t) {
-            if (!i.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
-            t = t || i.defaults;
-            var r = i.collectBundlePackets(e, t);
-            return i.joinParts(r);
-        }, i.isValidBundle = function(e) {
+        }, l.writeBundle = function(e, t) {
+            if (!l.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
+            t = t || l.defaults;
+            var r = l.collectBundlePackets(e, t);
+            return l.joinParts(r);
+        }, l.isValidBundle = function(e) {
             return void 0 !== e.timeTag && void 0 !== e.packets;
-        }, i.readBundleContents = function(e, t, r, n) {
-            for (var a = i.readTimeTag(e, r), o = []; r.idx < n; ) {
-                var s = i.readInt32(e, r), u = r.idx + s, c = i.readPacket(e, t, r, u);
-                o.push(c);
+        }, l.readBundleContents = function(e, t, r, n) {
+            for (var i = l.readTimeTag(e, r), a = []; r.idx < n; ) {
+                var o = l.readInt32(e, r), s = r.idx + o, u = l.readPacket(e, t, r, s);
+                a.push(u);
             }
             return {
-                timeTag: a,
-                packets: o
+                timeTag: i,
+                packets: a
             };
-        }, i.readPacket = function(e, t, r, n) {
-            var a = i.dataView(e, e.byteOffset, e.byteLength);
-            n = void 0 === n ? a.byteLength : n, r = r || {
+        }, l.readPacket = function(e, t, r, n) {
+            var i = l.dataView(e, e.byteOffset, e.byteLength);
+            n = void 0 === n ? i.byteLength : n, r = r || {
                 idx: 0
             };
-            var o = i.readString(a, r), s = o[0];
-            if ("#" === s) return i.readBundleContents(a, t, r, n);
-            if ("/" === s) return i.readMessageContents(o, a, t, r);
-            throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + o);
-        }, i.writePacket = function(e, t) {
-            if (i.isValidMessage(e)) return i.writeMessage(e, t);
-            if (i.isValidBundle(e)) return i.writeBundle(e, t);
+            var a = l.readString(i, r), o = a[0];
+            if ("#" === o) return l.readBundleContents(i, t, r, n);
+            if ("/" === o) return l.readMessageContents(a, i, t, r);
+            throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + a);
+        }, l.writePacket = function(e, t) {
+            if (l.isValidMessage(e)) return l.writeMessage(e, t);
+            if (l.isValidBundle(e)) return l.writeBundle(e, t);
             throw new Error("The specified packet was not recognized as a valid OSC message or bundle. Packet was: " + JSON.stringify(e, null, 2));
-        }, i.argumentTypes = {
+        }, l.argumentTypes = {
             i: {
                 reader: "readInt32",
                 writer: "writeInt32"
@@ -326,7 +326,7 @@
                 reader: "readMIDIBytes",
                 writer: "writeMIDIBytes"
             }
-        }, i.inferTypeForArgument = function(e) {
+        }, l.inferTypeForArgument = function(e) {
             switch (typeof e) {
               case "boolean":
                 return e ? "T" : "F";
@@ -346,82 +346,82 @@
                 if ("number" == typeof e.high && "number" == typeof e.low) return "h";
             }
             throw new Error("Can't infer OSC argument type for value: " + JSON.stringify(e, null, 2));
-        }, i.annotateArguments = function(e) {
+        }, l.annotateArguments = function(e) {
             for (var t = [], r = 0; r < e.length; r++) {
-                var n, a = e[r];
-                if ("object" == typeof a && a.type && void 0 !== a.value) n = a; else if (i.isArray(a)) n = i.annotateArguments(a); else {
+                var n, i = e[r];
+                if ("object" == typeof i && i.type && void 0 !== i.value) n = i; else if (l.isArray(i)) n = l.annotateArguments(i); else {
                     n = {
-                        type: i.inferTypeForArgument(a),
-                        value: a
+                        type: l.inferTypeForArgument(i),
+                        value: i
                     };
                 }
                 t.push(n);
             }
             return t;
-        }, i.isCommonJS && (module.exports = i);
+        }, l.isCommonJS && (module.exports = l);
     }();
-    i = i || require("./osc.js"), t = t || require("slip"), r = r || require("events").EventEmitter;
+    l = l || require("./osc.js"), i = i || require("slip"), t = t || require("events").EventEmitter;
     !function() {
         "use strict";
-        i.firePacketEvents = function(e, t, r, n) {
-            t.address ? e.emit("message", t, r, n) : i.fireBundleEvents(e, t, r, n);
-        }, i.fireBundleEvents = function(e, t, r, n) {
+        l.firePacketEvents = function(e, t, r, n) {
+            t.address ? e.emit("message", t, r, n) : l.fireBundleEvents(e, t, r, n);
+        }, l.fireBundleEvents = function(e, t, r, n) {
             e.emit("bundle", t, r, n);
-            for (var a = 0; a < t.packets.length; a++) {
-                var o = t.packets[a];
-                i.firePacketEvents(e, o, t.timeTag, n);
+            for (var i = 0; i < t.packets.length; i++) {
+                var a = t.packets[i];
+                l.firePacketEvents(e, a, t.timeTag, n);
             }
-        }, i.fireClosedPortSendError = function(e, t) {
+        }, l.fireClosedPortSendError = function(e, t) {
             t = t || "Can't send packets on a closed osc.Port object. Please open (or reopen) this Port by calling open().", 
             e.emit("error", t);
-        }, i.Port = function(e) {
+        }, l.Port = function(e) {
             this.options = e || {}, this.on("data", this.decodeOSC.bind(this));
         };
-        var e = i.Port.prototype = Object.create(r.prototype);
-        e.constructor = i.Port, e.send = function(e) {
-            var t = Array.prototype.slice.call(arguments), r = this.encodeOSC(e), n = i.nativeBuffer(r);
+        var e = l.Port.prototype = Object.create(t.prototype);
+        e.constructor = l.Port, e.send = function(e) {
+            var t = Array.prototype.slice.call(arguments), r = this.encodeOSC(e), n = l.nativeBuffer(r);
             t[0] = n, this.sendRaw.apply(this, t);
         }, e.encodeOSC = function(e) {
             var t;
             e = e.buffer ? e.buffer : e;
             try {
-                t = i.writePacket(e, this.options);
+                t = l.writePacket(e, this.options);
             } catch (e) {
                 this.emit("error", e);
             }
             return t;
         }, e.decodeOSC = function(e, t) {
-            e = i.byteArray(e), this.emit("raw", e, t);
+            e = l.byteArray(e), this.emit("raw", e, t);
             try {
-                var r = i.readPacket(e, this.options);
-                this.emit("osc", r, t), i.firePacketEvents(this, r, void 0, t);
+                var r = l.readPacket(e, this.options);
+                this.emit("osc", r, t), l.firePacketEvents(this, r, void 0, t);
             } catch (e) {
                 this.emit("error", e);
             }
-        }, i.SLIPPort = function(e) {
-            var r = this, n = this.options = e || {};
-            n.useSLIP = void 0 === n.useSLIP || n.useSLIP, this.decoder = new t.Decoder({
+        }, l.SLIPPort = function(e) {
+            var t = this, r = this.options = e || {};
+            r.useSLIP = void 0 === r.useSLIP || r.useSLIP, this.decoder = new i.Decoder({
                 onMessage: this.decodeOSC.bind(this),
                 onError: function(e) {
-                    r.emit("error", e);
+                    t.emit("error", e);
                 }
             });
-            var i = n.useSLIP ? this.decodeSLIPData : this.decodeOSC;
-            this.on("data", i.bind(this));
-        }, (e = i.SLIPPort.prototype = Object.create(i.Port.prototype)).constructor = i.SLIPPort, 
+            var n = r.useSLIP ? this.decodeSLIPData : this.decodeOSC;
+            this.on("data", n.bind(this));
+        }, (e = l.SLIPPort.prototype = Object.create(l.Port.prototype)).constructor = l.SLIPPort, 
         e.encodeOSC = function(e) {
-            var r;
+            var t;
             e = e.buffer ? e.buffer : e;
             try {
-                var n = i.writePacket(e, this.options);
-                r = t.encode(n);
+                var r = l.writePacket(e, this.options);
+                t = i.encode(r);
             } catch (e) {
                 this.emit("error", e);
             }
-            return r;
+            return t;
         }, e.decodeSLIPData = function(e, t) {
             this.decoder.decode(e, t);
-        }, i.relay = function(e, t, r, n, i, a) {
+        }, l.relay = function(e, t, r, n, i, a) {
             r = r || "message", n = n || "send", i = i || function() {}, a = a ? [ null ].concat(a) : [];
             var o = function(e) {
                 a[0] = e, e = i(e), t[n].apply(t, a);
@@ -430,56 +430,56 @@
                 eventName: r,
                 listener: o
             };
-        }, i.relayPorts = function(e, t, r) {
-            var n = r.raw ? "raw" : "osc", a = r.raw ? "sendRaw" : "send";
-            return i.relay(e, t, n, a, r.transform);
-        }, i.stopRelaying = function(e, t) {
+        }, l.relayPorts = function(e, t, r) {
+            var n = r.raw ? "raw" : "osc", i = r.raw ? "sendRaw" : "send";
+            return l.relay(e, t, n, i, r.transform);
+        }, l.stopRelaying = function(e, t) {
             e.removeListener(t.eventName, t.listener);
-        }, i.Relay = function(e, t, r) {
+        }, l.Relay = function(e, t, r) {
             (this.options = r || {}).raw = !1, this.port1 = e, this.port2 = t, this.listen();
-        }, (e = i.Relay.prototype = Object.create(r.prototype)).constructor = i.Relay, e.open = function() {
+        }, (e = l.Relay.prototype = Object.create(t.prototype)).constructor = l.Relay, e.open = function() {
             this.port1.open(), this.port2.open();
         }, e.listen = function() {
-            this.port1Spec && this.port2Spec && this.close(), this.port1Spec = i.relayPorts(this.port1, this.port2, this.options), 
-            this.port2Spec = i.relayPorts(this.port2, this.port1, this.options);
+            this.port1Spec && this.port2Spec && this.close(), this.port1Spec = l.relayPorts(this.port1, this.port2, this.options), 
+            this.port2Spec = l.relayPorts(this.port2, this.port1, this.options);
             var e = this.close.bind(this);
             this.port1.on("close", e), this.port2.on("close", e);
         }, e.close = function() {
-            i.stopRelaying(this.port1, this.port1Spec), i.stopRelaying(this.port2, this.port2Spec), 
+            l.stopRelaying(this.port1, this.port1Spec), l.stopRelaying(this.port2, this.port2Spec), 
             this.emit("close", this.port1, this.port2);
-        }, "undefined" != typeof module && module.exports && (module.exports = i);
+        }, "undefined" != typeof module && module.exports && (module.exports = l);
     }();
-    i = i || require("../osc.js");
+    l = l || require("../osc.js");
     return function() {
         "use strict";
-        i.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), i.WebSocketPort = function(e) {
-            i.Port.call(this, e), this.on("open", this.listen.bind(this)), this.socket = e.socket, 
-            this.socket && (1 === this.socket.readyState ? (i.WebSocketPort.setupSocketForBinary(this.socket), 
+        l.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), l.WebSocketPort = function(e) {
+            l.Port.call(this, e), this.on("open", this.listen.bind(this)), this.socket = e.socket, 
+            this.socket && (1 === this.socket.readyState ? (l.WebSocketPort.setupSocketForBinary(this.socket), 
             this.emit("open", this.socket)) : this.open());
         };
-        var e = i.WebSocketPort.prototype = Object.create(i.Port.prototype);
-        e.constructor = i.WebSocketPort, e.open = function() {
-            (!this.socket || this.socket.readyState > 1) && (this.socket = new i.WebSocket(this.options.url)), 
-            i.WebSocketPort.setupSocketForBinary(this.socket);
+        var e = l.WebSocketPort.prototype = Object.create(l.Port.prototype);
+        e.constructor = l.WebSocketPort, e.open = function() {
+            (!this.socket || 1 < this.socket.readyState) && (this.socket = new l.WebSocket(this.options.url)), 
+            l.WebSocketPort.setupSocketForBinary(this.socket);
             var e = this;
             this.socket.onopen = function() {
                 e.emit("open", e.socket);
             };
         }, e.listen = function() {
-            var e = this;
-            this.socket.onmessage = function(t) {
-                e.emit("data", t.data, t);
-            }, this.socket.onerror = function(t) {
-                e.emit("error", t);
-            }, this.socket.onclose = function(t) {
-                e.emit("close", t);
-            }, e.emit("ready");
+            var t = this;
+            this.socket.onmessage = function(e) {
+                t.emit("data", e.data, e);
+            }, this.socket.onerror = function(e) {
+                t.emit("error", e);
+            }, this.socket.onclose = function(e) {
+                t.emit("close", e);
+            }, t.emit("ready");
         }, e.sendRaw = function(e) {
-            this.socket && 1 === this.socket.readyState ? this.socket.send(e) : i.fireClosedPortSendError(this);
+            this.socket && 1 === this.socket.readyState ? this.socket.send(e) : l.fireClosedPortSendError(this);
         }, e.close = function(e, t) {
             this.socket.close(e, t);
-        }, i.WebSocketPort.setupSocketForBinary = function(e) {
-            e.binaryType = i.isNode ? "nodebuffer" : "arraybuffer";
+        }, l.WebSocketPort.setupSocketForBinary = function(e) {
+            e.binaryType = l.isNode ? "nodebuffer" : "arraybuffer";
         };
-    }(), i;
+    }(), l;
 });

--- a/dist/osc.min.js
+++ b/dist/osc.min.js
@@ -126,7 +126,7 @@ var osc = osc || {};
     }, osc.timeTag = function(r, e) {
         r = r || 0;
         var t = (e = e || Date.now()) / 1e3, n = Math.floor(t), a = t - n, o = Math.floor(r), s = a + (r - o);
-        if (s > 1) {
+        if (1 < s) {
             var i = Math.floor(s);
             o += i, s = s - i;
         }

--- a/package.json
+++ b/package.json
@@ -24,22 +24,23 @@
     ],
     "readmeFilename": "README.md",
     "devDependencies": {
-        "jquery": "3.3.1",
-        "infusion": "3.0.0-dev.20180326T173646Z.8c6a109b1",
-        "requirejs": "2.3.5",
-        "node-jqunit": "1.1.8",
-        "grunt": "1.0.2",
-        "grunt-contrib-concat": "1.0.1",
-        "grunt-contrib-uglify": "3.3.0",
+        "grunt": "1.0.3",
         "grunt-contrib-clean": "1.1.0",
-        "grunt-contrib-jshint": "1.1.0"
+        "grunt-contrib-concat": "1.0.1",
+        "grunt-contrib-jshint": "1.1.0",
+        "grunt-contrib-uglify": "3.3.0",
+        "infusion": "3.0.0-dev.20180326T173646Z.8c6a109b1",
+        "jquery": "3.3.1",
+        "node-jqunit": "1.1.8",
+        "requirejs": "2.3.5",
+        "testem": "2.8.0"
     },
     "dependencies": {
-        "wolfy87-eventemitter": "5.2.4",
         "long": "4.0.0",
-        "serialport": "6.0.5",
+        "serialport": "6.2.0",
         "slip": "1.0.2",
-        "ws": "5.1.1"
+        "wolfy87-eventemitter": "5.2.4",
+        "ws": "5.2.0"
     },
     "scripts": {
         "test": "npm run node-test && grunt && npm run browser-test",

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -112,7 +112,7 @@
     };
 
     p.sendRaw = function (encoded) {
-        if (!this.serialPort || !this.serialPort.isOpen()) {
+        if (!this.serialPort || !this.serialPort.isOpen) {
             osc.fireClosedPortSendError(this);
             return;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,21 +6,226 @@ abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+accepts@~1.3.4, accepts@~1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
+    mime-types "~2.1.18"
+    negotiator "0.6.1"
+
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+
+ansi-bgblack@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgblack/-/ansi-bgblack-0.1.1.tgz#a68ba5007887701b6aafbe3fa0dadfdfa8ee3ca2"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgblue@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgblue/-/ansi-bgblue-0.1.1.tgz#67bdc04edc9b9b5278969da196dea3d75c8c3613"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgcyan@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgcyan/-/ansi-bgcyan-0.1.1.tgz#58489425600bde9f5507068dd969ebfdb50fe768"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bggreen@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bggreen/-/ansi-bggreen-0.1.1.tgz#4e3191248529943f4321e96bf131d1c13816af49"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgmagenta@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgmagenta/-/ansi-bgmagenta-0.1.1.tgz#9b28432c076eaa999418672a3efbe19391c2c7a1"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgred@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgred/-/ansi-bgred-0.1.1.tgz#a76f92838382ba43290a6c1778424f984d6f1041"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgwhite@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgwhite/-/ansi-bgwhite-0.1.1.tgz#6504651377a58a6ececd0331994e480258e11ba8"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bgyellow@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bgyellow/-/ansi-bgyellow-0.1.1.tgz#c3fe2eb08cd476648029e6874d15a0b38f61d44f"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-black@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-black/-/ansi-black-0.1.1.tgz#f6185e889360b2545a1ec50c0bf063fc43032453"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-blue@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-blue/-/ansi-blue-0.1.1.tgz#15b804990e92fc9ca8c5476ce8f699777c21edbf"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-bold@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-bold/-/ansi-bold-0.1.1.tgz#3e63950af5acc2ae2e670e6f67deb115d1a5f505"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-colors@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-0.2.0.tgz#72c31de2a0d9a2ccd0cac30cc9823eeb2f6434b5"
+  dependencies:
+    ansi-bgblack "^0.1.1"
+    ansi-bgblue "^0.1.1"
+    ansi-bgcyan "^0.1.1"
+    ansi-bggreen "^0.1.1"
+    ansi-bgmagenta "^0.1.1"
+    ansi-bgred "^0.1.1"
+    ansi-bgwhite "^0.1.1"
+    ansi-bgyellow "^0.1.1"
+    ansi-black "^0.1.1"
+    ansi-blue "^0.1.1"
+    ansi-bold "^0.1.1"
+    ansi-cyan "^0.1.1"
+    ansi-dim "^0.1.1"
+    ansi-gray "^0.1.1"
+    ansi-green "^0.1.1"
+    ansi-grey "^0.1.1"
+    ansi-hidden "^0.1.1"
+    ansi-inverse "^0.1.1"
+    ansi-italic "^0.1.1"
+    ansi-magenta "^0.1.1"
+    ansi-red "^0.1.1"
+    ansi-reset "^0.1.1"
+    ansi-strikethrough "^0.1.1"
+    ansi-underline "^0.1.1"
+    ansi-white "^0.1.1"
+    ansi-yellow "^0.1.1"
+    lazy-cache "^2.0.1"
+
+ansi-cyan@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-dim@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-dim/-/ansi-dim-0.1.1.tgz#40de4c603aa8086d8e7a86b8ff998d5c36eefd6c"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-gray@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-gray/-/ansi-gray-0.1.1.tgz#2962cf54ec9792c48510a3deb524436861ef7251"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-green@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-green/-/ansi-green-0.1.1.tgz#8a5d9a979e458d57c40e33580b37390b8e10d0f7"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-grey@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-grey/-/ansi-grey-0.1.1.tgz#59d98b6ac2ba19f8a51798e9853fba78339a33c1"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-hidden@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-hidden/-/ansi-hidden-0.1.1.tgz#ed6a4c498d2bb7cbb289dbf2a8d1dcc8567fae0f"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-inverse@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-inverse/-/ansi-inverse-0.1.1.tgz#b6af45826fe826bfb528a6c79885794355ccd269"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-italic@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-italic/-/ansi-italic-0.1.1.tgz#104743463f625c142a036739cf85eda688986f23"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-magenta@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-magenta/-/ansi-magenta-0.1.1.tgz#063b5ba16fb3f23e1cfda2b07c0a89de11e430ae"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-red@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
+  dependencies:
+    ansi-wrap "0.1.0"
 
 ansi-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
+ansi-reset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-reset/-/ansi-reset-0.1.1.tgz#e7e71292c3c7ddcd4d62ef4a6c7c05980911c3b7"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-strikethrough@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-strikethrough/-/ansi-strikethrough-0.1.1.tgz#d84877140b2cff07d1c93ebce69904f68885e568"
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-underline@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-underline/-/ansi-underline-0.1.1.tgz#dfc920f4c97b5977ea162df8ffb988308aaa71a4"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-white@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-white/-/ansi-white-0.1.1.tgz#9c77b7c193c5ee992e6011d36ec4c921b4578944"
+  dependencies:
+    ansi-wrap "0.1.0"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+
+ansi-yellow@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-yellow/-/ansi-yellow-0.1.1.tgz#cb9356f2f46c732f0e3199e6102955a77da83c1d"
+  dependencies:
+    ansi-wrap "0.1.0"
 
 aproba@^1.0.3:
   version "1.0.4"
@@ -39,67 +244,111 @@ argparse@^1.0.2:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-swap@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arr-swap/-/arr-swap-1.0.1.tgz#147590ed65fc815bc07fef0997c2e5823d643534"
+  dependencies:
+    is-number "^3.0.0"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
-asn1@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+arraybuffer.slice@~0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
 
-assert-plus@^1.0.0:
+async-limiter@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@~0.2.6:
+async@~0.2.9:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+backbone@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.3.3.tgz#4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
+  dependencies:
+    underscore ">=1.8.3"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-
-aws4@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
 balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-bcrypt-pbkdf@^1.0.0:
+balanced-match@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz#3ca76b85241c7170bf7d9703e7b9aa74630040d4"
-  dependencies:
-    tweetnacl "^0.14.3"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-bindings@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  dependencies:
-    inherits "~2.0.0"
+base64id@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
   dependencies:
-    hoek "2.x.x"
+    callsite "1.0.0"
+
+bindings@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
+bl@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
+blob@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
+
+bluebird@^3.1.1, bluebird@^3.4.6:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
+body-parser@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.1"
+    http-errors "~1.6.2"
+    iconv-lite "0.4.19"
+    on-finished "~2.3.0"
+    qs "6.5.1"
+    raw-body "2.3.2"
+    type-is "~1.6.15"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -108,11 +357,33 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 browserify-zlib@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
   dependencies:
     pako "~0.2.0"
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-shims@^1.0.0:
   version "1.0.0"
@@ -122,6 +393,14 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -129,26 +408,11 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
-
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
-caseless@~0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
-
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
-
-chalk@^1.0.0, chalk@^1.1.1, chalk@~1.1.1:
+chalk@^1.0.0, chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -158,6 +422,32 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@~1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+charm@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
+  dependencies:
+    inherits "^2.0.1"
+
+choices-separator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/choices-separator/-/choices-separator-2.0.0.tgz#92fd1763182d79033f5c5c51d0ba352e5567c696"
+  dependencies:
+    ansi-dim "^0.1.1"
+    debug "^2.6.6"
+    strip-color "^0.1.0"
+
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 cli@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cli/-/cli-1.0.1.tgz#22817534f24bfa4950c34d532d48ecbc621b8c14"
@@ -165,37 +455,66 @@ cli@~1.0.0:
     exit "0.1.2"
     glob "^7.1.1"
 
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+clone-deep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-1.0.0.tgz#b2f354444b5d4a0ce58faca337ef34da2b14a6c7"
   dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^5.0.0"
+    shallow-clone "^1.0.0"
+
+clone-deep@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.0.tgz#a41ae54db9048b407d9c73e703297a12e1dfd932"
+  dependencies:
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
 
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-coffee-script@~1.10.0:
+coffeescript@~1.10.0:
   version "1.10.0"
-  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.10.0.tgz#12938bcf9be1948fa006f92e0c4c9e81705108c0"
+  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-1.10.0.tgz#e7aa8301917ef621b35d8a39f348dcdd1db7e33e"
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@^1.0.5, combined-stream@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
-  dependencies:
-    delayed-stream "~1.0.0"
+commander@^2.13.0, commander@^2.6.0, commander@~2.15.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
-commander@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+
+component-emitter@1.2.1, component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -219,27 +538,51 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+consolidate@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.15.1.tgz#21ab043235c71a07d45d9aad98593b0dba56bab7"
+  dependencies:
+    bluebird "^3.1.1"
+
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
-    boom "2.x.x"
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
   dependencies:
     array-find-index "^1.0.1"
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  dependencies:
-    assert-plus "^1.0.0"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -252,40 +595,70 @@ dateformat@~1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@^2.1.1:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+debug@2.6.9, debug@^2.6.6, debug@^2.6.8:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
-    ms "0.7.2"
+    ms "2.0.0"
 
-debug@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+debug@^3.0.1, debug@^3.1.0, debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
-    ms "0.7.1"
+    ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.2:
+decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-extend@~0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
-
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
+    mimic-response "^1.0.0"
 
-delayed-stream@~1.0.0:
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
+depd@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+
+depd@~1.1.1, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 dom-serializer@0:
   version "0.1.0"
@@ -315,11 +688,56 @@ domutils@1.5:
     dom-serializer "0"
     domelementtype "1"
 
-ecc-jsbn@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
-    jsbn "~0.1.0"
+    once "^1.4.0"
+
+engine.io-client@~3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.2.1.tgz#6f54c0475de487158a1a7c77d10178708b6add36"
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "~3.1.0"
+    engine.io-parser "~2.1.1"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~3.3.1"
+    xmlhttprequest-ssl "~1.5.4"
+    yeast "0.1.2"
+
+engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.1.2.tgz#4c0f4cff79aaeecbbdcfdea66a823c6085409196"
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "~0.0.7"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.4"
+    has-binary2 "~1.0.2"
+
+engine.io@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.2.0.tgz#54332506f42f2edc71690d2f2a42349359f3bf7d"
+  dependencies:
+    accepts "~1.3.4"
+    base64id "1.0.0"
+    cookie "0.3.1"
+    debug "~3.1.0"
+    engine.io-parser "~2.1.0"
+    ws "~3.3.1"
 
 entities@1.0:
   version "1.0.0"
@@ -335,6 +753,14 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-symbol@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/error-symbol/-/error-symbol-0.1.0.tgz#0a4dae37d600d15a29ba453d8ef920f1844333f6"
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -343,21 +769,86 @@ esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
 eventemitter2@~0.4.13:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
+
+eventemitter3@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
+
+events-to-array@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit@0.1.2, exit@0.1.x, exit@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
-extend@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
+expand-template@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
 
-extsprintf@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+express@^4.10.7:
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
+  dependencies:
+    accepts "~1.3.5"
+    array-flatten "1.1.1"
+    body-parser "1.18.2"
+    content-disposition "0.5.2"
+    content-type "~1.0.4"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.1.1"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.3"
+    qs "6.5.1"
+    range-parser "~1.2.0"
+    safe-buffer "5.1.1"
+    send "0.16.2"
+    serve-static "1.13.2"
+    setprototypeof "1.1.0"
+    statuses "~1.4.0"
+    type-is "~1.6.16"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
 
 figures@^1.0.1:
   version "1.7.0"
@@ -365,6 +856,18 @@ figures@^1.0.1:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+finalhandler@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.4.0"
+    unpipe "~1.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -379,50 +882,55 @@ findup-sync@~0.3.0:
   dependencies:
     glob "~5.0.0"
 
-fluid-resolve@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fluid-resolve/-/fluid-resolve-1.2.0.tgz#9bf0f3e47a84d591d4ccc5fcda4909dfaea23590"
-
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-
-form-data@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
+fireworm@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/fireworm/-/fireworm-0.7.1.tgz#ccf20f7941f108883fcddb99383dbe6e1861c758"
   dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
+    async "~0.2.9"
+    is-type "0.0.1"
+    lodash.debounce "^3.1.1"
+    lodash.flatten "^3.0.2"
+    minimatch "^3.0.2"
+
+fluid-resolve@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fluid-resolve/-/fluid-resolve-1.3.0.tgz#383029eb1a61969802bd85684c8e286e6d2c0dfd"
+
+follow-redirects@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
+  dependencies:
+    debug "^3.1.0"
+
+for-in@^0.1.3:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
+
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
+  dependencies:
+    for-in "^1.0.1"
+
+forwarded@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-
-fstream-ignore@~1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
-  dependencies:
-    fstream "^1.0.0"
-    inherits "2"
-    minimatch "^3.0.0"
-
-fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.10.tgz#604e8a92fe26ffd9f6fae30399d4984e1ab22822"
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
-
-function-bind@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 gauge@~2.7.1:
   version "2.7.2"
@@ -438,29 +946,45 @@ gauge@~2.7.1:
     supports-color "^0.2.0"
     wide-align "^1.1.0"
 
-generate-function@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
   dependencies:
-    is-property "^1.0.0"
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 getobject@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/getobject/-/getobject-0.1.0.tgz#047a449789fa160d018f5486ed91320b6ec7885c"
 
-getpass@^0.1.1:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+
+glob@^7.0.4:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
-    assert-plus "^1.0.0"
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.5, glob@~7.0.0:
   version "7.0.6"
@@ -498,9 +1022,9 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
 grunt-cli@~1.2.0:
   version "1.2.0"
@@ -511,76 +1035,74 @@ grunt-cli@~1.2.0:
     nopt "~3.0.6"
     resolve "~1.1.0"
 
-grunt-contrib-clean@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz#6b2ed94117e2c7ffe32ee04578c96fe4625a9b6d"
+grunt-contrib-clean@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz#564abf2d0378a983a15b9e3f30ee75b738c40638"
   dependencies:
     async "^1.5.2"
     rimraf "^2.5.1"
 
-grunt-contrib-concat@~1.0.1:
+grunt-contrib-concat@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz#61509863084e871d7e86de48c015259ed97745bd"
   dependencies:
     chalk "^1.0.0"
     source-map "^0.5.3"
 
-grunt-contrib-jshint@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-contrib-jshint/-/grunt-contrib-jshint-1.0.0.tgz#30f405a51de656bfa6eb029b9a464b9fe02a402a"
+grunt-contrib-jshint@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz#369d909b2593c40e8be79940b21340850c7939ac"
   dependencies:
     chalk "^1.1.1"
     hooker "^0.2.3"
-    jshint "~2.9.1"
+    jshint "~2.9.4"
 
-grunt-contrib-uglify@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz#ae67a46f9153edd4cb11813a55eb69c70d7db2fb"
+grunt-contrib-uglify@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-uglify/-/grunt-contrib-uglify-3.3.0.tgz#dcc29bee1dd4768698930e46fb8bff8e8d37fb08"
   dependencies:
     chalk "^1.0.0"
-    lodash "^4.0.1"
     maxmin "^1.1.0"
-    uglify-js "~2.6.2"
+    uglify-js "~3.3.0"
     uri-path "^1.0.0"
 
 grunt-known-options@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/grunt-known-options/-/grunt-known-options-1.1.0.tgz#a4274eeb32fa765da5a7a3b1712617ce3b144149"
 
-grunt-legacy-log-utils@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz#a7b8e2d0fb35b5a50f4af986fc112749ebc96f3d"
+grunt-legacy-log-utils@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz#d2f442c7c0150065d9004b08fd7410d37519194e"
   dependencies:
-    chalk "~1.1.1"
-    lodash "~4.3.0"
+    chalk "~2.4.1"
+    lodash "~4.17.10"
 
-grunt-legacy-log@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz#fb86f1809847bc07dc47843f9ecd6cacb62df2d5"
+grunt-legacy-log@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz#c8cd2c6c81a4465b9bbf2d874d963fef7a59ffb9"
   dependencies:
     colors "~1.1.2"
-    grunt-legacy-log-utils "~1.0.0"
+    grunt-legacy-log-utils "~2.0.0"
     hooker "~0.2.3"
-    lodash "~3.10.1"
-    underscore.string "~3.2.3"
+    lodash "~4.17.5"
 
-grunt-legacy-util@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz#386aa78dc6ed50986c2b18957265b1b48abb9b86"
+grunt-legacy-util@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz#e10624e7c86034e5b870c8a8616743f0a0845e42"
   dependencies:
     async "~1.5.2"
     exit "~0.1.1"
     getobject "~0.1.0"
     hooker "~0.2.3"
-    lodash "~4.3.0"
-    underscore.string "~3.2.3"
-    which "~1.2.1"
+    lodash "~4.17.10"
+    underscore.string "~3.3.4"
+    which "~1.3.0"
 
-grunt@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.0.1.tgz#e8778764e944b18f32bb0f10b9078475c9dfb56b"
+grunt@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/grunt/-/grunt-1.0.3.tgz#b3c99260c51d1b42835766e796527b60f7bba374"
   dependencies:
-    coffee-script "~1.10.0"
+    coffeescript "~1.10.0"
     dateformat "~1.0.12"
     eventemitter2 "~0.4.13"
     exit "~0.1.1"
@@ -588,14 +1110,15 @@ grunt@~1.0.1:
     glob "~7.0.0"
     grunt-cli "~1.2.0"
     grunt-known-options "~1.1.0"
-    grunt-legacy-log "~1.0.0"
-    grunt-legacy-util "~1.0.0"
+    grunt-legacy-log "~2.0.0"
+    grunt-legacy-util "~1.1.1"
     iconv-lite "~0.4.13"
     js-yaml "~3.5.2"
-    minimatch "~3.0.0"
+    minimatch "~3.0.2"
+    mkdirp "~0.5.1"
     nopt "~3.0.6"
     path-is-absolute "~1.0.0"
-    rimraf "~2.2.8"
+    rimraf "~2.6.2"
 
 gzip-size@^1.0.0:
   version "1.0.0"
@@ -604,37 +1127,29 @@ gzip-size@^1.0.0:
     browserify-zlib "^0.1.4"
     concat-stream "^1.4.1"
 
-har-validator@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-2.0.6.tgz#cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    is-my-json-valid "^2.12.4"
-    pinkie-promise "^2.0.0"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
 
+has-binary2@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
+  dependencies:
+    isarray "2.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
-
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hooker@^0.2.3, hooker@~0.2.3:
   version "0.2.3"
@@ -654,27 +1169,49 @@ htmlparser2@3.8.x:
     entities "1.0"
     readable-stream "1.1"
 
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
+http-errors@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
   dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
+    depd "1.1.1"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
+http-proxy@^1.13.1:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+  dependencies:
+    eventemitter3 "^3.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
+iconv-lite@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
-
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
 
 indent-string@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -683,25 +1220,45 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-infusion@2.0.0-dev.20151130T180545Z.18ee3f8:
-  version "2.0.0-dev.20151130T180545Z.18ee3f8"
-  resolved "https://registry.yarnpkg.com/infusion/-/infusion-2.0.0-dev.20151130T180545Z.18ee3f8.tgz#07ade23574f012178be2218a8f5141bab14bdaa2"
-  dependencies:
-    resolve "1.1.6"
+info-symbol@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/info-symbol/-/info-symbol-0.1.0.tgz#27841d72867ddb4242cd612d79c10633881c6a78"
 
-infusion@2.0.0-dev.20161002T002156Z.a2802df:
-  version "2.0.0-dev.20161002T002156Z.a2802df"
-  resolved "https://registry.yarnpkg.com/infusion/-/infusion-2.0.0-dev.20161002T002156Z.a2802df.tgz#92c1f7a93bfbcb8c217a9acb666bbadb1f3aca4d"
+infusion@3.0.0-dev.20171117T095227Z.67ff934:
+  version "3.0.0-dev.20171117T095227Z.67ff934"
+  resolved "https://registry.yarnpkg.com/infusion/-/infusion-3.0.0-dev.20171117T095227Z.67ff934.tgz#d0d836b343aa6db88c0decfeae71e6275d41420e"
   dependencies:
-    fluid-resolve "1.2.0"
+    fluid-resolve "1.3.0"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
+infusion@3.0.0-dev.20180326T173646Z.8c6a109b1:
+  version "3.0.0-dev.20180326T173646Z.8c6a109b1"
+  resolved "https://registry.yarnpkg.com/infusion/-/infusion-3.0.0-dev.20180326T173646Z.8c6a109b1.tgz#14d054aebc8db804ae5f4cbb5e0de651cad8b656"
+  dependencies:
+    fluid-resolve "1.3.0"
+
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+ipaddr.js@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
+
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -711,11 +1268,47 @@ is-buffer@^1.0.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
 is-builtin-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -729,52 +1322,74 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
-is-my-json-valid@^2.12.4:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
+    kind-of "^3.0.2"
 
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+is-number@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-6.0.0.tgz#e6d15ad31fc262887cccf217ae5f9316f81b1995"
 
-is-typedarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-type@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/is-type/-/is-type-0.0.1.tgz#f651d85c365d44955d14a51d8d7061f3f6b4779c"
+  dependencies:
+    core-util-is "~1.0.0"
 
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
 
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isexe@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-jodid25519@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
+jquery@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+
+js-yaml@^3.2.5, js-yaml@^3.2.7:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
-    jsbn "~0.1.0"
-
-jquery@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.3.tgz#45e07e4190334de36c9e1a64b43b1f1373d91758"
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@~3.5.2:
   version "3.5.5"
@@ -783,13 +1398,9 @@ js-yaml@~3.5.2:
     argparse "^1.0.2"
     esprima "^2.6.0"
 
-jsbn@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
-
-jshint@~2.9.1:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.4.tgz#5e3ba97848d5290273db514aee47fe24cf592934"
+jshint@~2.9.4:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/jshint/-/jshint-2.9.5.tgz#1e7252915ce681b40827ee14248c46d34e9aa62c"
   dependencies:
     cli "~1.0.0"
     console-browserify "1.1.x"
@@ -800,41 +1411,35 @@ jshint@~2.9.1:
     shelljs "0.3.x"
     strip-json-comments "1.0.x"
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-
-jsprim@^1.2.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.3.1.tgz#2a7256f70412a29ee3670aaca625994c4dcff252"
-  dependencies:
-    extsprintf "1.0.2"
-    json-schema "0.2.3"
-    verror "1.3.6"
-
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
 
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-
-lie@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.0.tgz#65e0139eaef9ae791a1f5c8c53692c8d3b4718f4"
+kind-of@^3.0.3:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
-    immediate "~3.0.5"
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0, kind-of@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+koalas@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/koalas/-/koalas-1.0.2.tgz#318433f074235db78fae5661a02a8ca53ee295cd"
+
+lazy-cache@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -846,29 +1451,92 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+lodash._baseflatten@^3.0.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz#0770ff80131af6e34f3b511796a7ba5214e65ff7"
+  dependencies:
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.assignin@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+
+lodash.clonedeep@^4.4.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
+lodash.debounce@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
+  dependencies:
+    lodash._getnative "^3.0.0"
+
+lodash.find@^4.5.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+
+lodash.flatten@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-3.0.2.tgz#de1cf57758f8f4479319d35c3e9cc60c4501938c"
+  dependencies:
+    lodash._baseflatten "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.uniqby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+
 lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-lodash@^4.0.1:
-  version "4.17.3"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.3.tgz#557ed7d2a9438cac5fd5a43043ca60cb455e01f7"
+lodash@~4.17.10, lodash@~4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@~3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+log-ok@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/log-ok/-/log-ok-0.1.1.tgz#bea3dd36acd0b8a7240d78736b5b97c65444a334"
+  dependencies:
+    ansi-green "^0.1.1"
+    success-symbol "^0.1.0"
 
-lodash@~4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.3.0.tgz#efd9c4a6ec53f3b05412429915c3e4824e4d25a4"
+log-utils@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/log-utils/-/log-utils-0.2.1.tgz#a4c217a0dd9a50515d9b920206091ab3d4e031cf"
+  dependencies:
+    ansi-colors "^0.2.0"
+    error-symbol "^0.1.0"
+    info-symbol "^0.1.0"
+    log-ok "^0.1.1"
+    success-symbol "^0.1.0"
+    time-stamp "^1.0.1"
+    warning-symbol "^0.1.0"
 
-long@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-3.1.0.tgz#e465c877d6235da66d446c59ad814801e8739d42"
-
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+long@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -881,6 +1549,12 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 maxmin@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/maxmin/-/maxmin-1.1.0.tgz#71365e84a99dd8f8b3f7d5fde2f00d1e7f73be61"
@@ -889,6 +1563,10 @@ maxmin@^1.1.0:
     figures "^1.0.1"
     gzip-size "^1.0.0"
     pretty-bytes "^1.0.0"
+
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
 meow@^3.1.0, meow@^3.3.0:
   version "3.7.0"
@@ -905,21 +1583,43 @@ meow@^3.1.0, meow@^3.3.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-mime-db@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
-  version "2.1.13"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+
+mime-types@~2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
-    mime-db "~1.25.0"
+    mime-db "~1.33.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.0, minimatch@~3.0.2:
+mime@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
+
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -929,43 +1629,74 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-"mkdirp@>=0.5 0", mkdirp@~0.5.1:
+minipass@^2.2.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+mixin-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-2.0.1.tgz#4fb949441dab182540f1fe035ba60e1947a5e57e"
+  dependencies:
+    for-in "^0.1.3"
+    is-extendable "^0.1.1"
+
+mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+mustache@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
 
-nan@^2.3.5:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-node-jqunit@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/node-jqunit/-/node-jqunit-1.1.4.tgz#682956a4adab3258e1da9b6d98cac488ae122744"
+nan@^2.9.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
+node-abi@^2.2.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923"
   dependencies:
-    infusion "2.0.0-dev.20151130T180545Z.18ee3f8"
+    semver "^5.4.1"
 
-node-pre-gyp@^0.6.26:
-  version "0.6.32"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz#fc452b376e7319b3d255f5f34853ef6fd8fe1fd5"
+node-jqunit@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/node-jqunit/-/node-jqunit-1.1.8.tgz#5aad4b27984754ca0f67502634f13002debe18d3"
   dependencies:
-    mkdirp "~0.5.1"
-    nopt "~3.0.6"
-    npmlog "^4.0.1"
-    rc "~1.1.6"
-    request "^2.79.0"
-    rimraf "~2.5.4"
-    semver "~5.3.0"
-    tar "~2.2.1"
-    tar-pack "~3.3.0"
+    infusion "3.0.0-dev.20171117T095227Z.67ff934"
+
+node-notifier@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
 
 nopt@~3.0.6:
   version "3.0.6"
@@ -982,6 +1713,21 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npmlog@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 npmlog@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -995,41 +1741,47 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-oauth-sign@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+object-component@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
-object.assign@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.0"
-    object-keys "^1.0.10"
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
 
-once@^1.3.0:
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  dependencies:
+    ee-first "1.1.1"
+
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
 
-once@~1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
-  dependencies:
-    wrappy "1"
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-options@>=0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -1041,6 +1793,59 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  dependencies:
+    better-assert "~1.0.0"
+
+parser-byte-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-byte-length/-/parser-byte-length-1.0.2.tgz#581c1e32949a7859087919607cc860eab76ddd59"
+  dependencies:
+    safe-buffer "^5.1.1"
+
+parser-cctalk@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-cctalk/-/parser-cctalk-1.0.2.tgz#1f99901b8799171427f8fd2307ec9e517c55a3b4"
+  dependencies:
+    safe-buffer "^5.1.1"
+
+parser-delimiter@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-delimiter/-/parser-delimiter-1.0.2.tgz#1087850069bb4418a3ee152e9384679bcba247c1"
+  dependencies:
+    safe-buffer "^5.1.1"
+
+parser-readline@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-readline/-/parser-readline-1.0.2.tgz#19d1c4856a646f64fe90be663ee2c545a09f36e3"
+  dependencies:
+    parser-delimiter "^1.0.2"
+    safe-buffer "^5.1.1"
+
+parser-ready@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-ready/-/parser-ready-1.0.2.tgz#da49dbf1f261846e1925c9e0c18093750c508315"
+  dependencies:
+    safe-buffer "^5.1.1"
+
+parser-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parser-regex/-/parser-regex-1.0.2.tgz#abbcd2a39895787fd54ac0373b2b61490f9703e7"
+  dependencies:
+    safe-buffer "^5.1.1"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  dependencies:
+    better-assert "~1.0.0"
+
+parseurl@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -1050,6 +1855,14 @@ path-exists@^2.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -1073,6 +1886,30 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pointer-symbol@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pointer-symbol/-/pointer-symbol-1.0.0.tgz#60f9110204ea7a929b62644a21315543cbb3d447"
+
+prebuild-install@^2.4.1:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.3.tgz#9f65f242782d370296353710e9bc843490c19f69"
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^1.0.2"
+    github-from-package "0.0.0"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    node-abi "^2.2.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    os-homedir "^1.0.1"
+    pump "^2.0.1"
+    rc "^1.1.6"
+    simple-get "^2.7.0"
+    tar-fs "^1.13.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
 pretty-bytes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
@@ -1080,26 +1917,152 @@ pretty-bytes@^1.0.0:
     get-stdin "^4.0.1"
     meow "^3.1.0"
 
+printf@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/printf/-/printf-0.3.0.tgz#6918ca5237c047e19cf004b69e6bcfafbef1ce82"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-qs@~6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
+promirepl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promirepl/-/promirepl-1.0.1.tgz#2951aaeba2bf3fe2274ff63a16d94c04ca60872e"
 
-rc@~1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.1.6.tgz#43651b76b6ae53b5c802f1151fa3fc3b059969c9"
+prompt-actions@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/prompt-actions/-/prompt-actions-3.0.2.tgz#537eee52241c940379f354a06eae8528e44ceeba"
   dependencies:
-    deep-extend "~0.4.0"
+    debug "^2.6.8"
+
+prompt-base@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/prompt-base/-/prompt-base-4.1.0.tgz#7b88e4c01b096c83d2f4e501a7e85f0d369ecd1f"
+  dependencies:
+    component-emitter "^1.2.1"
+    debug "^3.0.1"
+    koalas "^1.0.2"
+    log-utils "^0.2.1"
+    prompt-actions "^3.0.2"
+    prompt-question "^5.0.1"
+    readline-ui "^2.2.3"
+    readline-utils "^2.2.3"
+    static-extend "^0.1.2"
+
+prompt-checkbox@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/prompt-checkbox/-/prompt-checkbox-2.2.0.tgz#a1b086bac7e3422a3f1c34f66d6da52486472690"
+  dependencies:
+    ansi-cyan "^0.1.1"
+    debug "^2.6.8"
+    prompt-base "^4.0.2"
+
+prompt-choices@^4.0.5:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/prompt-choices/-/prompt-choices-4.1.0.tgz#6094202c4e55d0762e49c1e53735727e53fd484f"
+  dependencies:
+    arr-flatten "^1.1.0"
+    arr-swap "^1.0.1"
+    choices-separator "^2.0.0"
+    clone-deep "^4.0.0"
+    collection-visit "^1.0.0"
+    define-property "^2.0.2"
+    is-number "^6.0.0"
+    kind-of "^6.0.2"
+    koalas "^1.0.2"
+    log-utils "^0.2.1"
+    pointer-symbol "^1.0.0"
+    radio-symbol "^2.0.0"
+    set-value "^3.0.0"
+    strip-color "^0.1.0"
+    terminal-paginator "^2.0.2"
+    toggle-array "^1.0.1"
+
+prompt-list@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/prompt-list/-/prompt-list-3.2.0.tgz#b33472e01677a5751f59094fa7fe20b09da9db94"
+  dependencies:
+    ansi-cyan "^0.1.1"
+    ansi-dim "^0.1.1"
+    prompt-radio "^1.2.1"
+
+prompt-question@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/prompt-question/-/prompt-question-5.0.2.tgz#81a479f38f0bafecc758e5d6f7bc586e599610b3"
+  dependencies:
+    clone-deep "^1.0.0"
+    debug "^3.0.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    kind-of "^5.0.2"
+    koalas "^1.0.2"
+    prompt-choices "^4.0.5"
+
+prompt-radio@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prompt-radio/-/prompt-radio-1.2.1.tgz#66a4cb2b189d3373e7f9ddbbc10700186c8959ff"
+  dependencies:
+    debug "^2.6.8"
+    prompt-checkbox "^2.2.0"
+
+proxy-addr@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.6.0"
+
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+qs@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+radio-symbol@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/radio-symbol/-/radio-symbol-2.0.0.tgz#7aa9bfc50485636d52dd76d6a8e631b290799ae1"
+  dependencies:
+    ansi-gray "^0.1.1"
+    ansi-green "^0.1.1"
+    is-windows "^1.0.1"
+
+range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
+raw-body@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.2"
+    iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
+rc@^1.1.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
-    strip-json-comments "~1.0.4"
+    strip-json-comments "~2.0.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -1125,7 +2088,7 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@~2.1.4:
+"readable-stream@^2.0.0 || ^1.1.13":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -1149,6 +2112,41 @@ readable-stream@^2.2.2:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
+readable-stream@^2.3.0, readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readline-ui@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/readline-ui/-/readline-ui-2.2.3.tgz#9e873a7668bbd8ca8a5573ce810a6bafb70a5089"
+  dependencies:
+    component-emitter "^1.2.1"
+    debug "^2.6.8"
+    readline-utils "^2.2.1"
+    string-width "^2.0.0"
+
+readline-utils@^2.2.1, readline-utils@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/readline-utils/-/readline-utils-2.2.3.tgz#6f847d6b8f1915c391b581c367cd47873862351a"
+  dependencies:
+    arr-flatten "^1.1.0"
+    extend-shallow "^2.0.1"
+    is-buffer "^1.1.5"
+    is-number "^3.0.0"
+    is-windows "^1.0.1"
+    koalas "^1.0.2"
+    mute-stream "0.0.7"
+    strip-color "^0.1.0"
+    window-size "^1.1.0"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -1156,110 +2154,227 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-repeat-string@^1.5.2:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.11.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~2.0.6"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    qs "~6.3.0"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "~0.4.1"
-    uuid "^3.0.0"
+requirejs@2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.5.tgz#617b9acbbcb336540ef4914d790323a8d4b861b0"
 
-requirejs@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.2.0.tgz#0f2b1538af2b8d0a4fffffde5d367aa9cd4cfe84"
-
-resolve@1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.6.tgz#d3492ad054ca800f5befa612e61beac1eec98f8f"
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 resolve@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+rimraf@^2.4.4, rimraf@~2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
-    align-text "^0.1.1"
+    glob "^7.0.5"
 
-rimraf@2, rimraf@^2.5.1, rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@^2.5.1:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 
-rimraf@~2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+safe-buffer@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"semver@2 || 3 || 4 || 5", semver@~5.3.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+"semver@2 || 3 || 4 || 5":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-serialport@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/serialport/-/serialport-4.0.3.tgz#31339c4a13f9009852975204f6068c1a6a20a4a1"
+semver@^5.4.1, semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+send@0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
   dependencies:
-    bindings "1.2.1"
-    commander "^2.9.0"
-    debug "^2.1.1"
-    lie "^3.1.0"
-    nan "^2.3.5"
-    node-pre-gyp "^0.6.26"
-    object.assign "^4.0.3"
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.6.2"
+    mime "1.4.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.4.0"
+
+serialport@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/serialport/-/serialport-6.2.0.tgz#99413b30b160ff06711563a71324f0959c48a7a0"
+  dependencies:
+    bindings "1.3.0"
+    commander "^2.13.0"
+    debug "^3.1.0"
+    nan "^2.9.2"
+    parser-byte-length "^1.0.2"
+    parser-cctalk "^1.0.2"
+    parser-delimiter "^1.0.2"
+    parser-readline "^1.0.2"
+    parser-ready "^1.0.2"
+    parser-regex "^1.0.2"
+    prebuild-install "^2.4.1"
+    promirepl "^1.0.1"
+    prompt-list "^3.1.2"
+    safe-buffer "^5.0.1"
+
+serve-static@1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.2"
+    send "0.16.2"
 
 set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
+
+set-value@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.0.tgz#bc021514f46effed8176fd5f0f67e9988531141f"
+  dependencies:
+    is-plain-object "^2.0.4"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+shallow-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^5.0.0"
+    mixin-object "^2.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.0.tgz#317b701facce5e742d4c04c64e1d52f957e22b28"
+  dependencies:
+    kind-of "^6.0.2"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
+
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+
+simple-get@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
+  dependencies:
+    decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 slip@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/slip/-/slip-1.0.2.tgz#ba45a923034d6cf41b1a27aebe7128282c8d551f"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
+socket.io-adapter@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz#2a805e8a14d6372124dd9159ad4502f8cb07f06b"
 
-source-map@^0.5.3, source-map@~0.5.1:
+socket.io-client@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.1.1.tgz#dcb38103436ab4578ddb026638ae2f21b623671f"
+  dependencies:
+    backo2 "1.0.2"
+    base64-arraybuffer "0.1.5"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "~3.1.0"
+    engine.io-client "~3.2.0"
+    has-binary2 "~1.0.2"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    socket.io-parser "~3.2.0"
+    to-array "0.1.4"
+
+socket.io-parser@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.2.0.tgz#e7c6228b6aa1f814e6148aea325b51aa9499e077"
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~3.1.0"
+    isarray "2.0.1"
+
+socket.io@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.1.1.tgz#a069c5feabee3e6b214a75b40ce0652e1cfb9980"
+  dependencies:
+    debug "~3.1.0"
+    engine.io "~3.2.0"
+    has-binary2 "~1.0.2"
+    socket.io-adapter "~1.1.0"
+    socket.io-client "2.1.1"
+    socket.io-parser "~3.2.0"
+
+source-map@^0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+spawn-args@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/spawn-args/-/spawn-args-0.2.0.tgz#fb7d0bd1d70fd4316bd9e3dec389e65f9d6361bb"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -1275,24 +2390,28 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+sprintf-js@^1.0.3:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-sshpk@^1.7.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.10.1.tgz#30e1a5d329244974a1af61511339d595af6638b0"
+static-extend@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
   dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    dashdash "^1.12.0"
-    getpass "^0.1.1"
-  optionalDependencies:
-    bcrypt-pbkdf "^1.0.0"
-    ecc-jsbn "~0.1.1"
-    jodid25519 "^1.0.0"
-    jsbn "~0.1.0"
-    tweetnacl "~0.14.0"
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+
+statuses@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -1302,13 +2421,22 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-stringstream@~0.0.4:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -1316,11 +2444,25 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-color@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/strip-color/-/strip-color-0.1.0.tgz#106f65d3d3e6a2d9401cac0eb0ce8b8a702b4f7b"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -1328,9 +2470,21 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@1.0.x, strip-json-comments@~1.0.4:
+strip-json-comments@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+styled_string@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/styled_string/-/styled_string-0.0.1.tgz#d22782bd81295459bc4f1df18c4bad8e94dd124a"
+
+success-symbol@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/success-symbol/-/success-symbol-0.1.0.tgz#24022e486f3bf1cdca094283b769c472d3b72897"
 
 supports-color@^0.2.0:
   version "0.2.0"
@@ -1340,85 +2494,163 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-tar-pack@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.3.0.tgz#30931816418f55afc4d21775afdd6720cee45dae"
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
-    debug "~2.2.0"
-    fstream "~1.0.10"
-    fstream-ignore "~1.0.5"
-    once "~1.3.3"
-    readable-stream "~2.1.4"
-    rimraf "~2.5.1"
-    tar "~2.2.1"
-    uid-number "~0.0.6"
+    has-flag "^3.0.0"
 
-tar@~2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+tap-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-7.0.0.tgz#54db35302fda2c2ccc21954ad3be22b2cba42721"
   dependencies:
-    block-stream "*"
-    fstream "^1.0.2"
-    inherits "2"
+    events-to-array "^1.0.1"
+    js-yaml "^3.2.7"
+    minipass "^2.2.0"
 
-tough-cookie@~2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
+tar-fs@^1.13.0:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.2.tgz#17e5239747e399f7e77344f5f53365f04af53577"
   dependencies:
-    punycode "^1.4.1"
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
+tar-stream@^1.1.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.1.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.0"
+    xtend "^4.0.0"
+
+terminal-paginator@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/terminal-paginator/-/terminal-paginator-2.0.2.tgz#967e66056f28fe8f55ba7c1eebfb7c3ef371c1d3"
+  dependencies:
+    debug "^2.6.6"
+    extend-shallow "^2.0.1"
+    log-utils "^0.2.1"
+
+testem@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/testem/-/testem-2.8.0.tgz#1c9a8c8cc229e63e2331b1972fe1f5745ecdd1c2"
+  dependencies:
+    backbone "^1.1.2"
+    bluebird "^3.4.6"
+    charm "^1.0.0"
+    commander "^2.6.0"
+    consolidate "^0.15.1"
+    execa "^0.10.0"
+    express "^4.10.7"
+    fireworm "^0.7.0"
+    glob "^7.0.4"
+    http-proxy "^1.13.1"
+    js-yaml "^3.2.5"
+    lodash.assignin "^4.1.0"
+    lodash.castarray "^4.4.0"
+    lodash.clonedeep "^4.4.1"
+    lodash.find "^4.5.1"
+    lodash.uniqby "^4.7.0"
+    mkdirp "^0.5.1"
+    mustache "^2.2.1"
+    node-notifier "^5.0.1"
+    npmlog "^4.0.0"
+    printf "^0.3.0"
+    rimraf "^2.4.4"
+    socket.io "^2.1.0"
+    spawn-args "^0.2.0"
+    styled_string "0.0.1"
+    tap-parser "^7.0.0"
+    xmldom "^0.1.19"
+
+time-stamp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
+
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+
+to-buffer@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+toggle-array@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toggle-array/-/toggle-array-1.0.1.tgz#cbf5840792bd5097f33117ae824c932affe87d58"
+  dependencies:
+    isobject "^3.0.0"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
-tunnel-agent@~0.4.1:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
 
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+type-is@~1.6.15, type-is@~1.6.16:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
 
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@~2.6.2:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.6.4.tgz#65ea2fb3059c9394692f15fed87c2b36c16b9adf"
+uglify-js@~3.3.0:
+  version "3.3.28"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.28.tgz#0efb9a13850e11303361c1051f64d2ec68d9be06"
   dependencies:
-    async "~0.2.6"
-    source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
-    yargs "~3.10.0"
+    commander "~2.15.0"
+    source-map "~0.6.1"
 
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
-uid-number@~0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+underscore.string@~3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
+  dependencies:
+    sprintf-js "^1.0.3"
+    util-deprecate "^1.0.2"
 
-ultron@1.0.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+underscore@>=1.8.3:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
 
-underscore.string@~3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.2.3.tgz#806992633665d5e5fcb4db1fb3a862eb68e9e6da"
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
 uri-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/uri-path/-/uri-path-1.0.0.tgz#9747f018358933c31de0fccfd82d138e67262e32"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -1427,17 +2659,23 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-verror@1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
-  dependencies:
-    extsprintf "1.0.2"
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
-which@~1.2.1:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
+warning-symbol@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/warning-symbol/-/warning-symbol-0.1.0.tgz#bb31dd11b7a0f9d67ab2ed95f457b65825bbad21"
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+
+which@^1.2.9, which@^1.3.0, which@~1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
-    isexe "^1.1.1"
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.0"
@@ -1445,38 +2683,51 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.1"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+window-size@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-1.1.0.tgz#3b402d3244f35561db2c9761ad9d1e5286b07a2d"
+  dependencies:
+    define-property "^1.0.0"
+    is-number "^3.0.0"
 
-wolfy87-eventemitter@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.0.0.tgz#8a012e751e16d77f59abb51699c1034d7065a58b"
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+wolfy87-eventemitter@5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.4.tgz#5021d2952d3611cbcd195149711d9b595cd11d48"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-ws@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.0.tgz#c1d6fd1515d3ceff1f0ae2759bf5fd77030aad1d"
+ws@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
   dependencies:
-    options ">=0.0.5"
-    ultron "1.0.x"
+    async-limiter "~1.0.0"
+
+ws@~3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
+
+xmldom@^0.1.19:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+
+xmlhttprequest-ssl@~1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
 
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
+yallist@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
fixes an issue when depending on both `osc.js` and `serialport` latest versions.

`serialport.isOpen` is now a property

This breaking change was introduced in version 5

https://github.com/node-serialport/node-serialport/blob/master/UPGRADE_GUIDE.md#opening-and-closing

I don't understand how this didn't break before but I don't have time to investigate.

(Additionally this fixes Node.js 10 compat)