### PR TITLE
Make serialport an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "osc",
     "main": "src/platforms/osc-node.js",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "A JavaScript Open Sound Control (OSC) library that works in Node.js and the browser.",
     "author": "Colin Clark",
     "homepage": "https://github.com/colinbdclark/osc.js",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     },
     "dependencies": {
         "long": "4.0.0",
-        "serialport": "6.2.2",
         "slip": "1.0.2",
         "wolfy87-eventemitter": "5.2.5",
         "ws": "6.0.0"
+    },
+    "optionalDependencies": {
+        "serialport": "6.2.2"
     },
     "scripts": {
         "test": "npm run node-test && grunt && npm run browser-test",


### PR DESCRIPTION
The hard dependency to serialport is still causing problem, making it optional sounds reasonable while #119 is not guaranteed to be addressed anytime soon. Thanks again for the library.