### PR TITLE
Fixes gh-96: Makes the Node.js serialport module an optional dependency.

### DIFF
--- a/dist/osc-browser.js
+++ b/dist/osc-browser.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js
@@ -117,7 +117,7 @@ var osc = osc || {};
     osc.nativeBuffer = function (obj) {
         if (osc.isBufferEnv) {
             return osc.isBuffer(obj) ? obj :
-                new Buffer(obj.buffer ? obj : new Uint8Array(obj));
+                Buffer.from(obj.buffer ? obj : new Uint8Array(obj));
         }
 
         return osc.isTypedArrayView(obj) ? obj : new Uint8Array(obj);

--- a/dist/osc-browser.js
+++ b/dist/osc-browser.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc-browser.min.js
+++ b/dist/osc-browser.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};
@@ -25,7 +25,7 @@ var osc = osc || {};
         if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
         return new Uint8Array(t);
     }, osc.nativeBuffer = function(e) {
-        return osc.isBufferEnv ? osc.isBuffer(e) ? e : new Buffer(e.buffer ? e : new Uint8Array(e)) : osc.isTypedArrayView(e) ? e : new Uint8Array(e);
+        return osc.isBufferEnv ? osc.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : osc.isTypedArrayView(e) ? e : new Uint8Array(e);
     }, osc.copyByteArray = function(e, t, r) {
         if (osc.isTypedArrayView(e) && osc.isTypedArrayView(t)) t.set(e, r); else for (var n = void 0 === r ? 0 : r, i = Math.min(t.length - r, e.length), s = 0, o = n; s < i; s++, 
         o++) t[o] = e[s];

--- a/dist/osc-browser.min.js
+++ b/dist/osc-browser.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};

--- a/dist/osc-chromeapp.js
+++ b/dist/osc-chromeapp.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js
@@ -117,7 +117,7 @@ var osc = osc || {};
     osc.nativeBuffer = function (obj) {
         if (osc.isBufferEnv) {
             return osc.isBuffer(obj) ? obj :
-                new Buffer(obj.buffer ? obj : new Uint8Array(obj));
+                Buffer.from(obj.buffer ? obj : new Uint8Array(obj));
         }
 
         return osc.isTypedArrayView(obj) ? obj : new Uint8Array(obj);

--- a/dist/osc-chromeapp.js
+++ b/dist/osc-chromeapp.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc-chromeapp.min.js
+++ b/dist/osc-chromeapp.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};

--- a/dist/osc-chromeapp.min.js
+++ b/dist/osc-chromeapp.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};
@@ -25,7 +25,7 @@ var osc = osc || {};
         if (!(e instanceof ArrayBuffer || void 0 !== e.length && "string" != typeof e)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(t, null, 2));
         return new Uint8Array(e);
     }, osc.nativeBuffer = function(t) {
-        return osc.isBufferEnv ? osc.isBuffer(t) ? t : new Buffer(t.buffer ? t : new Uint8Array(t)) : osc.isTypedArrayView(t) ? t : new Uint8Array(t);
+        return osc.isBufferEnv ? osc.isBuffer(t) ? t : Buffer.from(t.buffer ? t : new Uint8Array(t)) : osc.isTypedArrayView(t) ? t : new Uint8Array(t);
     }, osc.copyByteArray = function(t, e, r) {
         if (osc.isTypedArrayView(t) && osc.isTypedArrayView(e)) e.set(t, r); else for (var n = void 0 === r ? 0 : r, i = Math.min(e.length - r, t.length), s = 0, o = n; s < i; s++, 
         o++) e[o] = t[s];

--- a/dist/osc-module.js
+++ b/dist/osc-module.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 (function (root, factory) {
     if (typeof exports === "object") {
@@ -135,7 +135,7 @@ var osc = osc || {};
     osc.nativeBuffer = function (obj) {
         if (osc.isBufferEnv) {
             return osc.isBuffer(obj) ? obj :
-                new Buffer(obj.buffer ? obj : new Uint8Array(obj));
+                Buffer.from(obj.buffer ? obj : new Uint8Array(obj));
         }
 
         return osc.isTypedArrayView(obj) ? obj : new Uint8Array(obj);

--- a/dist/osc-module.js
+++ b/dist/osc-module.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 (function (root, factory) {
     if (typeof exports === "object") {

--- a/dist/osc-module.min.js
+++ b/dist/osc-module.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 !function(i, a) {
@@ -28,7 +28,7 @@
             if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
             return new Uint8Array(t);
         }, l.nativeBuffer = function(e) {
-            return l.isBufferEnv ? l.isBuffer(e) ? e : new Buffer(e.buffer ? e : new Uint8Array(e)) : l.isTypedArrayView(e) ? e : new Uint8Array(e);
+            return l.isBufferEnv ? l.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : l.isTypedArrayView(e) ? e : new Uint8Array(e);
         }, l.copyByteArray = function(e, t, r) {
             if (l.isTypedArrayView(e) && l.isTypedArrayView(t)) t.set(e, r); else for (var n = void 0 === r ? 0 : r, i = Math.min(t.length - r, e.length), a = 0, o = n; a < i; a++, 
             o++) t[o] = e[a];

--- a/dist/osc-module.min.js
+++ b/dist/osc-module.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 !function(i, a) {

--- a/dist/osc.js
+++ b/dist/osc.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js
@@ -117,7 +117,7 @@ var osc = osc || {};
     osc.nativeBuffer = function (obj) {
         if (osc.isBufferEnv) {
             return osc.isBuffer(obj) ? obj :
-                new Buffer(obj.buffer ? obj : new Uint8Array(obj));
+                Buffer.from(obj.buffer ? obj : new Uint8Array(obj));
         }
 
         return osc.isTypedArrayView(obj) ? obj : new Uint8Array(obj);

--- a/dist/osc.js
+++ b/dist/osc.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc.min.js
+++ b/dist/osc.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.3.0, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};

--- a/dist/osc.min.js
+++ b/dist/osc.min.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.2.4, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.2.5, Copyright 2019 Colin Clark | github.com/colinbdclark/osc.js */
 
 
 var osc = osc || {};
@@ -25,7 +25,7 @@ var osc = osc || {};
         if (!(e instanceof ArrayBuffer || void 0 !== e.length && "string" != typeof e)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(r, null, 2));
         return new Uint8Array(e);
     }, osc.nativeBuffer = function(r) {
-        return osc.isBufferEnv ? osc.isBuffer(r) ? r : new Buffer(r.buffer ? r : new Uint8Array(r)) : osc.isTypedArrayView(r) ? r : new Uint8Array(r);
+        return osc.isBufferEnv ? osc.isBuffer(r) ? r : Buffer.from(r.buffer ? r : new Uint8Array(r)) : osc.isTypedArrayView(r) ? r : new Uint8Array(r);
     }, osc.copyByteArray = function(r, e, t) {
         if (osc.isTypedArrayView(r) && osc.isTypedArrayView(e)) e.set(r, t); else for (var n = void 0 === t ? 0 : t, a = Math.min(e.length - t, r.length), o = 0, s = n; o < a; o++, 
         s++) e[s] = r[o];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "osc",
     "main": "src/platforms/osc-node.js",
-    "version": "2.2.5",
+    "version": "2.3.0",
     "description": "A JavaScript Open Sound Control (OSC) library that works in Node.js and the browser.",
     "author": "Colin Clark",
     "homepage": "https://github.com/colinbdclark/osc.js",

--- a/src/osc.js
+++ b/src/osc.js
@@ -115,7 +115,7 @@ var osc = osc || {};
     osc.nativeBuffer = function (obj) {
         if (osc.isBufferEnv) {
             return osc.isBuffer(obj) ? obj :
-                new Buffer(obj.buffer ? obj : new Uint8Array(obj));
+                Buffer.from(obj.buffer ? obj : new Uint8Array(obj));
         }
 
         return osc.isTypedArrayView(obj) ? obj : new Uint8Array(obj);

--- a/src/platforms/osc-node-serialport.js
+++ b/src/platforms/osc-node-serialport.js
@@ -1,0 +1,92 @@
+/*
+ * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js
+ *
+ * Node.js serial transport for osc.js
+ *
+ * Copyright 2014-2019, Colin Clark
+ * Licensed under the MIT and GPL 3 licenses.
+ */
+
+/*jshint node:true*/
+
+var osc = osc || require("../osc.js");
+
+try {
+    var SerialPort = require("serialport");
+} catch (err) {
+    osc.SerialPort = function () {
+        throw new Error("The Node.js SerialPort library is not installed. osc.js' serial transport is unavailable.");
+    };
+
+    return;
+}
+
+osc.SerialPort = function (options) {
+    this.on("open", this.listen.bind(this));
+    osc.SLIPPort.call(this, options);
+    this.options.bitrate = this.options.bitrate || 9600;
+
+    this.serialPort = options.serialPort;
+    if (this.serialPort) {
+        this.emit("open", this.serialPort);
+    }
+};
+
+var p = osc.SerialPort.prototype = Object.create(osc.SLIPPort.prototype);
+p.constructor = osc.SerialPort;
+
+p.open = function () {
+    if (this.serialPort) {
+        // If we already have a serial port, close it and open a new one.
+        this.once("close", this.open.bind(this));
+        this.close();
+        return;
+    }
+
+    var that = this;
+
+    this.serialPort = new SerialPort(this.options.devicePath, {
+        baudRate: this.options.bitrate,
+        autoOpen: false
+    });
+
+    this.serialPort.on("error", function (err) {
+        that.emit("error", err);
+    });
+
+    this.serialPort.on("open", function () {
+        that.emit("open", that.serialPort);
+    });
+
+    this.serialPort.open();
+};
+
+p.listen = function () {
+    var that = this;
+
+    this.serialPort.on("data", function (data) {
+        that.emit("data", data, undefined);
+    });
+
+    this.serialPort.on("close", function () {
+        that.emit("close");
+    });
+
+    that.emit("ready");
+};
+
+p.sendRaw = function (encoded) {
+    if (!this.serialPort || !this.serialPort.isOpen) {
+        osc.fireClosedPortSendError(this);
+        return;
+    }
+
+    var that = this;
+    this.serialPort.write(encoded);
+};
+
+p.close = function () {
+    if (this.serialPort) {
+        this.serialPort.close();
+    }
+};

--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -29,89 +29,15 @@
     };
 
     var dgram = require("dgram"),
-        SerialPort = require("serialport"),
         net = require("net"),
         WebSocket = require("ws"),
         modules = [
             require("../osc.js"),
             require("../osc-transports.js"),
-            require("./osc-websocket-client.js")
+            require("./osc-websocket-client.js"),
+            require("./osc-node-serialport.js")
         ],
         osc = shallowMerge({}, modules);
-
-    /**********
-     * Serial *
-     **********/
-
-    osc.SerialPort = function (options) {
-        this.on("open", this.listen.bind(this));
-        osc.SLIPPort.call(this, options);
-        this.options.bitrate = this.options.bitrate || 9600;
-
-        this.serialPort = options.serialPort;
-        if (this.serialPort) {
-            this.emit("open", this.serialPort);
-        }
-    };
-
-    var p = osc.SerialPort.prototype = Object.create(osc.SLIPPort.prototype);
-    p.constructor = osc.SerialPort;
-
-    p.open = function () {
-        if (this.serialPort) {
-            // If we already have a serial port, close it and open a new one.
-            this.once("close", this.open.bind(this));
-            this.close();
-            return;
-        }
-
-        var that = this;
-
-        this.serialPort = new SerialPort(this.options.devicePath, {
-            baudRate: this.options.bitrate,
-            autoOpen: false
-        });
-
-        this.serialPort.on("error", function (err) {
-            that.emit("error", err);
-        });
-
-        this.serialPort.on("open", function () {
-            that.emit("open", that.serialPort);
-        });
-
-        this.serialPort.open();
-    };
-
-    p.listen = function () {
-        var that = this;
-
-        this.serialPort.on("data", function (data) {
-            that.emit("data", data, undefined);
-        });
-
-        this.serialPort.on("close", function () {
-            that.emit("close");
-        });
-
-        that.emit("ready");
-    };
-
-    p.sendRaw = function (encoded) {
-        if (!this.serialPort || !this.serialPort.isOpen) {
-            osc.fireClosedPortSendError(this);
-            return;
-        }
-
-        var that = this;
-        this.serialPort.write(encoded);
-    };
-
-    p.close = function () {
-        if (this.serialPort) {
-            this.serialPort.close();
-        }
-    };
 
 
     /*******
@@ -137,7 +63,7 @@
         }
     };
 
-    p = osc.UDPPort.prototype = Object.create(osc.Port.prototype);
+    var p = osc.UDPPort.prototype = Object.create(osc.Port.prototype);
     p.constructor = osc.UDPPort;
 
     p.open = function () {
@@ -292,7 +218,7 @@
             return;
         }
 
-        encoded = new Buffer(encoded);
+        encoded = Buffer.from(encoded);
 
         try {
             this.socket.write(encoded);

--- a/tests/node-buffer-tests.js
+++ b/tests/node-buffer-tests.js
@@ -21,7 +21,7 @@ var QUnit = fluid.registerNamespace("QUnit");
 jqUnit.module("Node.js buffer tests");
 
 // "/oscillator/4/frequency" | ",f" | 440
-var oscMessageBuffer = new Buffer([
+var oscMessageBuffer = Buffer.from([
     0x2f, 0x6f, 0x73, 0x63,
     0x69, 0x6c, 0x6c, 0x61,
     0x74, 0x6f, 0x72, 0x2f,
@@ -57,7 +57,7 @@ var testOSCBlobMessage = {
     args: [
         {
             type: "b",
-            value: new Buffer([
+            value: Buffer.from([
                 0, 0, 0, 3,            // Length 3
                 0x63, 0x61, 0x74, 0   // raw bytes
             ])


### PR DESCRIPTION
This PR builds on @jean-emmanuel's fix in #138 by ensuring that the <code>osc.SerialPort</code> constructor will throw an informative error if it's called when the optional <code>serialport</code> dependency hasn't successfully been installed.

Also removes deprecated use of <code>new Buffer()</code>, just for tidiness.