### PR TITLE
Listen and retrigger error from osc.WebSocket object

### DIFF
--- a/src/platforms/osc-websocket-client.js
+++ b/src/platforms/osc-websocket-client.js
@@ -46,6 +46,11 @@ var osc = osc || require("../osc.js");
         this.socket.onopen = function () {
             that.emit("open", that.socket);
         };
+        
+        this.socket.onerror = function (err) {
+            that.emit("error", err);
+        };
+        
     };
 
     p.listen = function () {

--- a/src/platforms/osc-websocket-client.js
+++ b/src/platforms/osc-websocket-client.js
@@ -59,10 +59,6 @@ var osc = osc || require("../osc.js");
             that.emit("data", e.data, e);
         };
 
-        this.socket.onerror = function (err) {
-            that.emit("error", err);
-        };
-
         this.socket.onclose = function (e) {
             that.emit("close", e);
         };


### PR DESCRIPTION
If an error at the `osc.WebSocket` level is not retriggered upstream, then it is impossible to catch it with the `error` listener on the `osc.WebSocketPort` object.