### PR TITLE
Fix: Optional serialport not working

### DIFF
--- a/src/platforms/osc-node.js
+++ b/src/platforms/osc-node.js
@@ -35,7 +35,7 @@
             require("../osc.js"),
             require("../osc-transports.js"),
             require("./osc-websocket-client.js"),
-            require("./osc-node-serialport.js")
+            require("./osc-node-serialport-loader.js")
         ],
         osc = shallowMerge({}, modules);
 


### PR DESCRIPTION
This PR fixes an issue causing a crash if the optional serialport dependency is not loaded.

Steps to reproduce:
* `git clone https://github.com/nytamin/oscOptionalSerialPortTest.git`
* `npm install --no-optional` <- _use the `no-optional` to make sure the serialport library isn't loaded_
* `node index.js`

This renders the error:
```
Error: Cannot find module 'serialport'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (.\node_modules\osc\src\platforms\osc-node-serialport.js:13:18)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```

It looks like the `osc-node-serialport-loader.js` file introduced in #147 was never used.