### PR TITLE
bump ws to mitigate advisory 1748

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
         "grunt": "1.0.4",
         "grunt-contrib-clean": "2.0.0",
         "grunt-contrib-concat": "1.0.1",
-        "grunt-replace": "1.0.1",
         "grunt-contrib-jshint": "2.1.0",
         "grunt-contrib-uglify": "4.0.1",
+        "grunt-replace": "1.0.1",
         "infusion": "3.0.0-dev.20190905T163833Z.b024bff87",
         "jquery": "3.4.1",
         "node-jqunit": "1.1.8",
@@ -40,7 +40,7 @@
         "long": "4.0.0",
         "slip": "1.0.2",
         "wolfy87-eventemitter": "5.2.9",
-        "ws": "7.2.1"
+        "ws": "^7.5.0"
     },
     "optionalDependencies": {
         "serialport": "8.0.6"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "long": "4.0.0",
         "slip": "1.0.2",
         "wolfy87-eventemitter": "5.2.9",
-        "ws": "^7.5.0"
+        "ws": "7.5.1"
     },
     "optionalDependencies": {
         "serialport": "8.0.6"


### PR DESCRIPTION
https://www.npmjs.com/advisories/1748/

Additionally, and apologies if you've clarified this elsewhere that I've missed, but I wonder why all packages are locked to a specific patch version, rather than using the best practice of allowing the major range? This way, patches would not be required for transitive security vulnerabilities. If you're strongly against it, I'm happy to amend my PR to remove the ^.