### PR TITLE
Don't truncate when dealing with unicode/encoded strings

### DIFF
--- a/src/osc.js
+++ b/src/osc.js
@@ -208,20 +208,20 @@ var osc = osc || {};
      */
     osc.writeString = function (str) {
         var terminated = str + "\u0000",
-            len = terminated.length,
-            paddedLen = (len + 3) & ~0x03,
-            arr = new Uint8Array(paddedLen);
-
         var encoder = osc.isBufferEnv ? osc.writeString.withBuffer :
             osc.TextEncoder ? osc.writeString.withTextEncoder : null,
             encodedStr;
 
         if (encoder) {
-            encodedStr = encoder(terminated);
+            terminated = encoder(terminated);
         }
 
+        len = terminated.length,
+        paddedLen = (len + 3) & ~0x03,
+        arr = new Uint8Array(paddedLen);
+
         for (var i = 0; i < terminated.length; i++) {
-            var charCode = encoder ? encodedStr[i] : terminated.charCodeAt(i);
+            var charCode = encoder ? terminated[i] : terminated.charCodeAt(i);
             arr[i] = charCode;
         }
 


### PR DESCRIPTION
When encoding unicode chars like `ç` osc.js writeString method would encode and convert the string to UInt8Array but still use the old string length, this results in incomplete bytes when constructing the final array.

For example:

`("çç" + "\u0000").length == 3`

if you encode that string you end up with an array with the length of 5, but with the old code the returned array was already created with the padded length of 4. in the end you have an incomplete string.