### PR TITLE
chore: update serialport to use NAPI

### DIFF
--- a/dist/osc-browser.js
+++ b/dist/osc-browser.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc-browser.min.js
+++ b/dist/osc-browser.min.js
@@ -1,9 +1,5 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
-
-
-var osc = osc || {};
-
-!function() {
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
+var osc = osc || {}, osc = (!function() {
     "use strict";
     osc.SECS_70YRS = 2208988800, osc.TWO_32 = 4294967296, osc.defaults = {
         metadata: !1,
@@ -24,8 +20,8 @@ var osc = osc || {};
     }, osc.byteArray = function(e) {
         if (e instanceof Uint8Array) return e;
         var t = e.buffer || e;
-        if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
-        return new Uint8Array(t);
+        if (t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t) return new Uint8Array(t);
+        throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
     }, osc.nativeBuffer = function(e) {
         return osc.isBufferEnv ? osc.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : osc.isTypedArrayView(e) ? e : new Uint8Array(e);
     }, osc.copyByteArray = function(e, t, r) {
@@ -63,8 +59,8 @@ var osc = osc || {};
     }, osc.writeString.withBuffer = function(e) {
         return Buffer.from(e);
     }, osc.readPrimitive = function(e, t, r, n) {
-        t = e[t](n.idx, !1);
-        return n.idx += r, t;
+        e = e[t](n.idx, !1);
+        return n.idx += r, e;
     }, osc.writePrimitive = function(e, t, r, n, i) {
         var s;
         return i = void 0 === i ? 0 : i, t ? s = new Uint8Array(t.buffer) : (s = new Uint8Array(n), 
@@ -74,10 +70,10 @@ var osc = osc || {};
     }, osc.writeInt32 = function(e, t, r) {
         return osc.writePrimitive(e, t, "setInt32", 4, r);
     }, osc.readInt64 = function(e, t) {
-        var r = osc.readPrimitive(e, "getInt32", 4, t), t = osc.readPrimitive(e, "getInt32", 4, t);
-        return osc.Long ? new osc.Long(t, r) : {
+        var r = osc.readPrimitive(e, "getInt32", 4, t), e = osc.readPrimitive(e, "getInt32", 4, t);
+        return osc.Long ? new osc.Long(e, r) : {
             high: r,
-            low: t,
+            low: e,
             unsigned: !1
         };
     }, osc.writeInt64 = function(e, t, r) {
@@ -93,14 +89,14 @@ var osc = osc || {};
     }, osc.writeFloat64 = function(e, t, r) {
         return osc.writePrimitive(e, t, "setFloat64", 8, r);
     }, osc.readChar32 = function(e, t) {
-        t = osc.readPrimitive(e, "getUint32", 4, t);
-        return String.fromCharCode(t);
+        e = osc.readPrimitive(e, "getUint32", 4, t);
+        return String.fromCharCode(e);
     }, osc.writeChar32 = function(e, t, r) {
         e = e.charCodeAt(0);
         if (!(void 0 === e || e < -1)) return osc.writePrimitive(e, t, "setUint32", 4, r);
     }, osc.readBlob = function(e, t) {
-        var r = osc.readInt32(e, t), n = r + 3 & -4, r = new Uint8Array(e.buffer, t.idx, r);
-        return t.idx += n, r;
+        var r = osc.readInt32(e, t), n = r + 3 & -4, e = new Uint8Array(e.buffer, t.idx, r);
+        return t.idx += n, e;
     }, osc.writeBlob = function(e) {
         var t = (e = osc.byteArray(e)).byteLength, r = new Uint8Array(4 + (t + 3 & -4)), n = new DataView(r.buffer);
         return osc.writeInt32(t, n), r.set(e, 4), r;
@@ -112,12 +108,12 @@ var osc = osc || {};
         var t = new Uint8Array(4);
         return t.set(e), t;
     }, osc.readColor = function(e, t) {
-        var r = new Uint8Array(e.buffer, t.idx, 4), e = r[3] / 255;
+        var e = new Uint8Array(e.buffer, t.idx, 4), r = e[3] / 255;
         return t.idx += 4, {
-            r: r[0],
-            g: r[1],
-            b: r[2],
-            a: e
+            r: e[0],
+            g: e[1],
+            b: e[2],
+            a: r
         };
     }, osc.writeColor = function(e) {
         var t = Math.round(255 * e.a);
@@ -131,25 +127,25 @@ var osc = osc || {};
     }, osc.readImpulse = function() {
         return 1;
     }, osc.readTimeTag = function(e, t) {
-        var r = osc.readPrimitive(e, "getUint32", 4, t), t = osc.readPrimitive(e, "getUint32", 4, t);
+        var r = osc.readPrimitive(e, "getUint32", 4, t), e = osc.readPrimitive(e, "getUint32", 4, t);
         return {
-            raw: [ r, t ],
-            native: 0 === r && 1 === t ? Date.now() : osc.ntpToJSTime(r, t)
+            raw: [ r, e ],
+            native: 0 === r && 1 === e ? Date.now() : osc.ntpToJSTime(r, e)
         };
     }, osc.writeTimeTag = function(e) {
-        var t = e.raw || osc.jsToNTPTime(e.native), r = new Uint8Array(8), e = new DataView(r.buffer);
-        return osc.writeInt32(t[0], e, 0), osc.writeInt32(t[1], e, 4), r;
+        var e = e.raw || osc.jsToNTPTime(e.native), t = new Uint8Array(8), r = new DataView(t.buffer);
+        return osc.writeInt32(e[0], r, 0), osc.writeInt32(e[1], r, 4), t;
     }, osc.timeTag = function(e, t) {
         e = e || 0;
-        var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), t = r - n, r = Math.floor(e), t = t + (e - r);
-        return 1 < t && (r += e = Math.floor(t), t = t - e), {
-            raw: [ n + r + osc.SECS_70YRS, Math.round(osc.TWO_32 * t) ]
+        var t = (t = t || Date.now()) / 1e3, r = Math.floor(t), t = t - r, n = Math.floor(e), t = t + (e - n);
+        return 1 < t && (n += e = Math.floor(t), t = t - e), {
+            raw: [ r + n + osc.SECS_70YRS, Math.round(osc.TWO_32 * t) ]
         };
     }, osc.ntpToJSTime = function(e, t) {
         return 1e3 * (e - osc.SECS_70YRS + t / osc.TWO_32);
     }, osc.jsToNTPTime = function(e) {
-        var t = e / 1e3, e = Math.floor(t);
-        return [ e + osc.SECS_70YRS, Math.round(osc.TWO_32 * (t - e)) ];
+        var e = e / 1e3, t = Math.floor(e);
+        return [ t + osc.SECS_70YRS, Math.round(osc.TWO_32 * (e - t)) ];
     }, osc.readArguments = function(e, t, r) {
         var n = osc.readString(e, r);
         if (0 !== n.indexOf(",")) throw new Error("A malformed type tag string was found while reading the arguments of an OSC message. String was: " + n, " at offset: " + r.idx);
@@ -158,26 +154,26 @@ var osc = osc || {};
     }, osc.readArgument = function(e, t, r, n, i) {
         var s = osc.argumentTypes[e];
         if (!s) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + t);
-        s = s.reader, i = osc[s](r, i);
-        return i = n.metadata ? {
+        t = s.reader, s = osc[t](r, i);
+        return s = n.metadata ? {
             type: e,
-            value: i
-        } : i;
+            value: s
+        } : s;
     }, osc.readArgumentsIntoArray = function(e, t, r, n, i, s) {
         for (var o = 0; o < t.length; ) {
             var a = t[o];
             if ("[" === a) {
                 var u = t.slice(o + 1), c = u.indexOf("]");
                 if (c < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + r);
-                var u = u.slice(0, c), u = osc.readArgumentsIntoArray([], u, r, n, i, s);
+                u = u.slice(0, c), u = osc.readArgumentsIntoArray([], u, r, n, i, s);
                 o += c + 2;
             } else u = osc.readArgument(a, r, n, i, s), o++;
             e.push(u);
         }
         return e;
     }, osc.writeArguments = function(e, t) {
-        t = osc.collectArguments(e, t);
-        return osc.joinParts(t);
+        e = osc.collectArguments(e, t);
+        return osc.joinParts(e);
     }, osc.joinParts = function(e) {
         for (var t = new Uint8Array(e.byteLength), r = e.parts, n = 0, i = 0; i < r.length; i++) {
             var s = r[i];
@@ -201,24 +197,24 @@ var osc = osc || {};
             byteLength: 0,
             parts: []
         }, t.metadata || (e = osc.annotateArguments(e));
-        for (var n = ",", i = r.parts.length, s = 0; s < e.length; s++) {
-            var o = e[s];
-            n += osc.writeArgument(o, r);
+        for (var n = ",", t = r.parts.length, i = 0; i < e.length; i++) {
+            var s = e[i];
+            n += osc.writeArgument(s, r);
         }
-        t = osc.writeString(n);
-        return r.byteLength += t.byteLength, r.parts.splice(i, 0, t), r;
+        var o = osc.writeString(n);
+        return r.byteLength += o.byteLength, r.parts.splice(t, 0, o), r;
     }, osc.readMessage = function(e, t, r) {
         t = t || osc.defaults;
-        var n = osc.dataView(e, e.byteOffset, e.byteLength), e = osc.readString(n, r = r || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), n = osc.readString(e, r = r || {
             idx: 0
         });
-        return osc.readMessageContents(e, n, t, r);
+        return osc.readMessageContents(n, e, t, r);
     }, osc.readMessageContents = function(e, t, r, n) {
         if (0 !== e.indexOf("/")) throw new Error("A malformed OSC address was found while reading an OSC message. String was: " + e);
-        n = osc.readArguments(t, r, n);
+        t = osc.readArguments(t, r, n);
         return {
             address: e,
-            args: 1 === n.length && r.unpackSingleArgs ? n[0] : n
+            args: 1 === t.length && r.unpackSingleArgs ? t[0] : t
         };
     }, osc.collectMessageParts = function(e, t, r) {
         return r = r || {
@@ -227,8 +223,8 @@ var osc = osc || {};
         }, osc.addDataPart(osc.writeString(e.address), r), osc.collectArguments(e.args, t, r);
     }, osc.writeMessage = function(e, t) {
         if (t = t || osc.defaults, !osc.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
-        t = osc.collectMessageParts(e, t);
-        return osc.joinParts(t);
+        e = osc.collectMessageParts(e, t);
+        return osc.joinParts(e);
     }, osc.isValidMessage = function(e) {
         return e.address && 0 === e.address.indexOf("/");
     }, osc.readBundle = function(e, t, r) {
@@ -247,8 +243,8 @@ var osc = osc || {};
     }, osc.writeBundle = function(e, t) {
         if (!osc.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
         t = t || osc.defaults;
-        t = osc.collectBundlePackets(e, t);
-        return osc.joinParts(t);
+        e = osc.collectBundlePackets(e, t);
+        return osc.joinParts(e);
     }, osc.isValidBundle = function(e) {
         return void 0 !== e.timeTag && void 0 !== e.packets;
     }, osc.readBundleContents = function(e, t, r, n) {
@@ -261,14 +257,13 @@ var osc = osc || {};
             packets: s
         };
     }, osc.readPacket = function(e, t, r, n) {
-        var i = osc.dataView(e, e.byteOffset, e.byteLength);
-        n = void 0 === n ? i.byteLength : n;
-        var s = osc.readString(i, r = r || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), i = (n = void 0 === n ? e.byteLength : n, 
+        osc.readString(e, r = r || {
             idx: 0
-        }), e = s[0];
-        if ("#" === e) return osc.readBundleContents(i, t, r, n);
-        if ("/" === e) return osc.readMessageContents(s, i, t, r);
-        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + s);
+        })), s = i[0];
+        if ("#" === s) return osc.readBundleContents(e, t, r, n);
+        if ("/" === s) return osc.readMessageContents(i, e, t, r);
+        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + i);
     }, osc.writePacket = function(e, t) {
         if (osc.isValidMessage(e)) return osc.writeMessage(e, t);
         if (osc.isValidBundle(e)) return osc.writeBundle(e, t);
@@ -360,7 +355,7 @@ var osc = osc || {};
         }
         return t;
     }, osc.isCommonJS && (module.exports = osc);
-}(), function(e, t) {
+}(), !function(e, t) {
     "object" == typeof exports && "object" == typeof module ? module.exports = t() : "function" == typeof define && define.amd ? define([], t) : "object" == typeof exports ? exports.Long = t() : e.Long = t();
 }("undefined" != typeof self ? self : this, function() {
     return r = [ function(e, t) {
@@ -414,27 +409,12 @@ var osc = osc || {};
         Object.defineProperty(n.prototype, "__isLong__", {
             value: !0
         }), n.isLong = d;
-        var s = {}, o = {};
-        n.fromInt = r, n.fromNumber = g, n.fromBits = l;
-        var h = Math.pow;
-        n.fromString = c, n.fromValue = p;
-        var i = 4294967296, a = i * i, u = a / 2, y = r(1 << 24), m = r(0);
-        n.ZERO = m;
-        var f = r(0, !0);
-        n.UZERO = f;
-        var v = r(1);
-        n.ONE = v;
-        var b = r(1, !0);
-        n.UONE = b;
-        var E = r(-1);
-        n.NEG_ONE = E;
-        var S = l(-1, 2147483647, !1);
-        n.MAX_VALUE = S;
-        var A = l(-1, -1, !0);
-        n.MAX_UNSIGNED_VALUE = A;
-        var B = l(0, -2147483648, !1);
-        n.MIN_VALUE = B;
-        var P = n.prototype;
+        var s = {}, o = {}, h = (n.fromInt = r, n.fromNumber = g, n.fromBits = l, 
+        Math.pow), i = (n.fromString = c, n.fromValue = p, 4294967296), a = i * i, u = a / 2, y = r(1 << 24), m = r(0), f = (n.ZERO = m, 
+        r(0, !0)), v = (n.UZERO = f, r(1)), b = (n.ONE = v, r(1, !0)), E = (n.UONE = b, 
+        r(-1)), S = (n.NEG_ONE = E, l(-1, 2147483647, !1)), A = (n.MAX_VALUE = S, 
+        l(-1, -1, !0)), B = (n.MAX_UNSIGNED_VALUE = A, l(0, -2147483648, !1)), P = (n.MIN_VALUE = B, 
+        n.prototype);
         P.toInt = function() {
             return this.unsigned ? this.low >>> 0 : this.low;
         }, P.toNumber = function() {
@@ -442,13 +422,9 @@ var osc = osc || {};
         }, P.toString = function(e) {
             if ((e = e || 10) < 2 || 36 < e) throw RangeError("radix");
             if (this.isZero()) return "0";
-            if (this.isNegative()) {
-                if (this.eq(B)) {
-                    var t = g(e), r = this.div(t), t = r.mul(t).sub(this);
-                    return r.toString(e) + t.toInt().toString(e);
-                }
-                return "-" + this.neg().toString(e);
-            }
+            var t, r;
+            if (this.isNegative()) return this.eq(B) ? (r = g(e), r = (t = this.div(r)).mul(r).sub(this), 
+            t.toString(e) + r.toInt().toString(e)) : "-" + this.neg().toString(e);
             for (var n = g(h(e, 6), this.unsigned), i = this, s = ""; ;) {
                 var o = i.div(n), a = (i.sub(o.mul(n)).toInt() >>> 0).toString(e);
                 if ((i = o).isZero()) return a + s;
@@ -465,7 +441,7 @@ var osc = osc || {};
             return this.low >>> 0;
         }, P.getNumBitsAbs = function() {
             if (this.isNegative()) return this.eq(B) ? 64 : this.neg().getNumBitsAbs();
-            for (var e = 0 != this.high ? this.high : this.low, t = 31; 0 < t && 0 == (e & 1 << t); t--) ;
+            for (var e = 0 != this.high ? this.high : this.low, t = 31; 0 < t && 0 == (e & 1 << t); t--);
             return 0 != this.high ? t + 33 : t + 1;
         }, P.isZero = function() {
             return 0 === this.high && 0 === this.low;
@@ -498,8 +474,8 @@ var osc = osc || {};
         }, P.neg = P.negate, P.add = function(e) {
             d(e) || (e = p(e));
             var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, a = e.low >>> 16, u = 0, c = 0, h = 0, f = 0;
-            return h += (f += i + (65535 & e.low)) >>> 16, c += (h += n + a) >>> 16, u += (c += r + o) >>> 16, 
-            u += t + s, l((h &= 65535) << 16 | (f &= 65535), (u &= 65535) << 16 | (c &= 65535), this.unsigned);
+            return c += (h = h + ((f += i + (65535 & e.low)) >>> 16) + (n + a)) >>> 16, 
+            l((h &= 65535) << 16 | (f &= 65535), ((u += (c += r + o) >>> 16) + (t + s) & 65535) << 16 | (c &= 65535), this.unsigned);
         }, P.subtract = function(e) {
             return d(e) || (e = p(e)), this.add(e.neg());
         }, P.sub = P.subtract, P.multiply = function(e) {
@@ -511,17 +487,15 @@ var osc = osc || {};
             if (this.isNegative()) return e.isNegative() ? this.neg().mul(e.neg()) : this.neg().mul(e).neg();
             if (e.isNegative()) return this.mul(e.neg()).neg();
             if (this.lt(y) && e.lt(y)) return g(this.toNumber() * e.toNumber(), this.unsigned);
-            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, a = e.low >>> 16, u = 65535 & e.low, c = 0, h = 0, f = 0, e = 0;
-            return f += (e += i * u) >>> 16, h += (f += n * u) >>> 16, f &= 65535, h += (f += i * a) >>> 16, 
-            c += (h += r * u) >>> 16, h &= 65535, c += (h += n * a) >>> 16, h &= 65535, c += (h += i * o) >>> 16, 
-            c += t * u + r * a + n * o + i * s, l((f &= 65535) << 16 | (e &= 65535), (c &= 65535) << 16 | (h &= 65535), this.unsigned);
+            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, a = e.low >>> 16, e = 65535 & e.low, u = 0, c = 0, h = 0, f = (f = 0) + ((c = c + ((h += i * e) >>> 16) + n * e) >>> 16) + ((c = (c & 65535) + i * a) >>> 16);
+            return l((c &= 65535) << 16 | (h &= 65535), ((u += (f += r * e) >>> 16) + ((f = (f & 65535) + n * a) >>> 16) + ((f = (f & 65535) + i * o) >>> 16) + (t * e + r * a + n * o + i * s) & 65535) << 16 | (f &= 65535), this.unsigned);
         }, P.mul = P.multiply, P.divide = function(e) {
-            if ((e = !d(e) ? p(e) : e).isZero()) throw Error("division by zero");
+            if ((e = d(e) ? e : p(e)).isZero()) throw Error("division by zero");
             if (w) return this.unsigned || -2147483648 !== this.high || -1 !== e.low || -1 !== e.high ? l((this.unsigned ? w.div_u : w.div_s)(this.low, this.high, e.low, e.high), w.get_high(), this.unsigned) : this;
             if (this.isZero()) return this.unsigned ? f : m;
             var t, r;
             if (this.unsigned) {
-                if ((e = !e.unsigned ? e.toUnsigned() : e).gt(this)) return f;
+                if ((e = e.unsigned ? e : e.toUnsigned()).gt(this)) return f;
                 if (e.gt(this.shru(1))) return b;
                 r = f;
             } else {
@@ -600,22 +574,22 @@ var osc = osc || {};
         return r[e].call(t.exports, t, t.exports, n), t.l = !0, t.exports;
     }
     var r, i;
-}), function(t, r) {
+}), !function(t, r) {
     "use strict";
     "object" == typeof exports ? (t.slip = exports, r(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(e) {
         return t.slip = e, t.slip, r(e);
     }) : (t.slip = {}, r(t.slip));
 }(this, function(e) {
     "use strict";
-    var o = e;
-    o.END = 192, o.ESC = 219, o.ESC_END = 220, o.ESC_ESC = 221, o.byteArray = function(e, t, r) {
+    var o = e, e = (o.END = 192, o.ESC = 219, o.ESC_END = 220, o.ESC_ESC = 221, 
+    o.byteArray = function(e, t, r) {
         return e instanceof ArrayBuffer ? new Uint8Array(e, t, r) : e;
     }, o.expandByteArray = function(e) {
         var t = new Uint8Array(2 * e.length);
         return t.set(e), t;
     }, o.sliceByteArray = function(e, t, r) {
-        r = e.buffer.slice ? e.buffer.slice(t, r) : e.subarray(t, r);
-        return new Uint8Array(r);
+        e = e.buffer.slice ? e.buffer.slice(t, r) : e.subarray(t, r);
+        return new Uint8Array(e);
     }, o.encode = function(e, t) {
         (t = t || {}).bufferPadding = t.bufferPadding || 4;
         var t = (e = o.byteArray(e, t.offset, t.byteLength)).length + t.bufferPadding + 3 & -4, r = new Uint8Array(t), n = 1;
@@ -631,9 +605,9 @@ var osc = osc || {};
         this.maxMessageSize = (e = "function" != typeof e ? e || {} : {
             onMessage: e
         }).maxMessageSize || 10485760, this.bufferSize = e.bufferSize || 1024, this.msgBuffer = new Uint8Array(this.bufferSize), 
-        this.msgBufferIdx = 0, this.onMessage = e.onMessage, this.onError = e.onError, this.escape = !1;
-    };
-    e = o.Decoder.prototype;
+        this.msgBufferIdx = 0, this.onMessage = e.onMessage, this.onError = e.onError, 
+        this.escape = !1;
+    }, o.Decoder.prototype);
     return e.decode = function(e) {
         var t;
         e = o.byteArray(e);
@@ -659,12 +633,11 @@ var osc = osc || {};
         return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = o.expandByteArray(this.msgBuffer)), 
         this.msgBuffer[this.msgBufferIdx++] = e, this.escape = !1, this.msgBuffer.length < this.maxMessageSize;
     }, e.handleEnd = function() {
-        if (0 !== this.msgBufferIdx) {
-            var e = o.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
-            return this.onMessage && this.onMessage(e), this.msgBufferIdx = 0, e;
-        }
+        var e;
+        if (0 !== this.msgBufferIdx) return e = o.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx), 
+        this.onMessage && this.onMessage(e), this.msgBufferIdx = 0, e;
     }, o;
-}), function(e) {
+}), !function(e) {
     "use strict";
     function t() {}
     var r = t.prototype, n = e.EventEmitter;
@@ -742,11 +715,7 @@ var osc = osc || {};
     }, "function" == typeof define && define.amd ? define(function() {
         return t;
     }) : "object" == typeof module && module.exports ? module.exports = t : e.EventEmitter = t;
-}("undefined" != typeof window ? window : this || {});
-
-var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitter = EventEmitter || require("events").EventEmitter;
-
-!function() {
+}("undefined" != typeof window ? window : this || {}), osc || require("./osc.js")), slip = slip || require("slip"), EventEmitter = EventEmitter || require("events").EventEmitter, osc = (!function() {
     "use strict";
     osc.supportsSerial = !1, osc.firePacketEvents = function(e, t, r, n) {
         t.address ? e.emit("message", t, r, n) : osc.fireBundleEvents(e, t, r, n);
@@ -783,14 +752,13 @@ var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitt
             this.emit("error", e);
         }
     }, osc.SLIPPort = function(e) {
-        var t = this, e = this.options = e || {};
-        e.useSLIP = void 0 === e.useSLIP || e.useSLIP, this.decoder = new slip.Decoder({
+        var t = this, e = this.options = e || {}, e = (e.useSLIP = void 0 === e.useSLIP || e.useSLIP, 
+        this.decoder = new slip.Decoder({
             onMessage: this.decodeOSC.bind(this),
             onError: function(e) {
                 t.emit("error", e);
             }
-        });
-        e = e.useSLIP ? this.decodeSLIPData : this.decodeOSC;
+        }), e.useSLIP ? this.decodeSLIPData : this.decodeOSC);
         this.on("data", e.bind(this));
     }, (e = osc.SLIPPort.prototype = Object.create(osc.Port.prototype)).constructor = osc.SLIPPort, 
     e.encodeOSC = function(e) {
@@ -831,13 +799,12 @@ var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitt
         osc.stopRelaying(this.port1, this.port1Spec), osc.stopRelaying(this.port2, this.port2Spec), 
         this.emit("close", this.port1, this.port2);
     }, "undefined" != typeof module && module.exports && (module.exports = osc);
-}();
-
-osc = osc || require("./osc.js");
+}(), osc || require("./osc.js"));
 
 !function() {
     "use strict";
-    osc.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), osc.WebSocketPort = function(e) {
+    osc.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), 
+    osc.WebSocketPort = function(e) {
         osc.Port.call(this, e), this.on("open", this.listen.bind(this)), this.socket = e.socket, 
         this.socket && (1 === this.socket.readyState ? (osc.WebSocketPort.setupSocketForBinary(this.socket), 
         this.emit("open", this.socket)) : this.open());

--- a/dist/osc-chromeapp.js
+++ b/dist/osc-chromeapp.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc-chromeapp.min.js
+++ b/dist/osc-chromeapp.min.js
@@ -1,9 +1,5 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
-
-
-var osc = osc || {};
-
-!function() {
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
+var osc = osc || {}, osc = (!function() {
     "use strict";
     osc.SECS_70YRS = 2208988800, osc.TWO_32 = 4294967296, osc.defaults = {
         metadata: !1,
@@ -24,8 +20,8 @@ var osc = osc || {};
     }, osc.byteArray = function(e) {
         if (e instanceof Uint8Array) return e;
         var t = e.buffer || e;
-        if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
-        return new Uint8Array(t);
+        if (t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t) return new Uint8Array(t);
+        throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
     }, osc.nativeBuffer = function(e) {
         return osc.isBufferEnv ? osc.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : osc.isTypedArrayView(e) ? e : new Uint8Array(e);
     }, osc.copyByteArray = function(e, t, r) {
@@ -63,8 +59,8 @@ var osc = osc || {};
     }, osc.writeString.withBuffer = function(e) {
         return Buffer.from(e);
     }, osc.readPrimitive = function(e, t, r, n) {
-        t = e[t](n.idx, !1);
-        return n.idx += r, t;
+        e = e[t](n.idx, !1);
+        return n.idx += r, e;
     }, osc.writePrimitive = function(e, t, r, n, i) {
         var s;
         return i = void 0 === i ? 0 : i, t ? s = new Uint8Array(t.buffer) : (s = new Uint8Array(n), 
@@ -74,10 +70,10 @@ var osc = osc || {};
     }, osc.writeInt32 = function(e, t, r) {
         return osc.writePrimitive(e, t, "setInt32", 4, r);
     }, osc.readInt64 = function(e, t) {
-        var r = osc.readPrimitive(e, "getInt32", 4, t), t = osc.readPrimitive(e, "getInt32", 4, t);
-        return osc.Long ? new osc.Long(t, r) : {
+        var r = osc.readPrimitive(e, "getInt32", 4, t), e = osc.readPrimitive(e, "getInt32", 4, t);
+        return osc.Long ? new osc.Long(e, r) : {
             high: r,
-            low: t,
+            low: e,
             unsigned: !1
         };
     }, osc.writeInt64 = function(e, t, r) {
@@ -93,14 +89,14 @@ var osc = osc || {};
     }, osc.writeFloat64 = function(e, t, r) {
         return osc.writePrimitive(e, t, "setFloat64", 8, r);
     }, osc.readChar32 = function(e, t) {
-        t = osc.readPrimitive(e, "getUint32", 4, t);
-        return String.fromCharCode(t);
+        e = osc.readPrimitive(e, "getUint32", 4, t);
+        return String.fromCharCode(e);
     }, osc.writeChar32 = function(e, t, r) {
         e = e.charCodeAt(0);
         if (!(void 0 === e || e < -1)) return osc.writePrimitive(e, t, "setUint32", 4, r);
     }, osc.readBlob = function(e, t) {
-        var r = osc.readInt32(e, t), n = r + 3 & -4, r = new Uint8Array(e.buffer, t.idx, r);
-        return t.idx += n, r;
+        var r = osc.readInt32(e, t), n = r + 3 & -4, e = new Uint8Array(e.buffer, t.idx, r);
+        return t.idx += n, e;
     }, osc.writeBlob = function(e) {
         var t = (e = osc.byteArray(e)).byteLength, r = new Uint8Array(4 + (t + 3 & -4)), n = new DataView(r.buffer);
         return osc.writeInt32(t, n), r.set(e, 4), r;
@@ -112,12 +108,12 @@ var osc = osc || {};
         var t = new Uint8Array(4);
         return t.set(e), t;
     }, osc.readColor = function(e, t) {
-        var r = new Uint8Array(e.buffer, t.idx, 4), e = r[3] / 255;
+        var e = new Uint8Array(e.buffer, t.idx, 4), r = e[3] / 255;
         return t.idx += 4, {
-            r: r[0],
-            g: r[1],
-            b: r[2],
-            a: e
+            r: e[0],
+            g: e[1],
+            b: e[2],
+            a: r
         };
     }, osc.writeColor = function(e) {
         var t = Math.round(255 * e.a);
@@ -131,25 +127,25 @@ var osc = osc || {};
     }, osc.readImpulse = function() {
         return 1;
     }, osc.readTimeTag = function(e, t) {
-        var r = osc.readPrimitive(e, "getUint32", 4, t), t = osc.readPrimitive(e, "getUint32", 4, t);
+        var r = osc.readPrimitive(e, "getUint32", 4, t), e = osc.readPrimitive(e, "getUint32", 4, t);
         return {
-            raw: [ r, t ],
-            native: 0 === r && 1 === t ? Date.now() : osc.ntpToJSTime(r, t)
+            raw: [ r, e ],
+            native: 0 === r && 1 === e ? Date.now() : osc.ntpToJSTime(r, e)
         };
     }, osc.writeTimeTag = function(e) {
-        var t = e.raw || osc.jsToNTPTime(e.native), r = new Uint8Array(8), e = new DataView(r.buffer);
-        return osc.writeInt32(t[0], e, 0), osc.writeInt32(t[1], e, 4), r;
+        var e = e.raw || osc.jsToNTPTime(e.native), t = new Uint8Array(8), r = new DataView(t.buffer);
+        return osc.writeInt32(e[0], r, 0), osc.writeInt32(e[1], r, 4), t;
     }, osc.timeTag = function(e, t) {
         e = e || 0;
-        var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), t = r - n, r = Math.floor(e), t = t + (e - r);
-        return 1 < t && (r += e = Math.floor(t), t = t - e), {
-            raw: [ n + r + osc.SECS_70YRS, Math.round(osc.TWO_32 * t) ]
+        var t = (t = t || Date.now()) / 1e3, r = Math.floor(t), t = t - r, n = Math.floor(e), t = t + (e - n);
+        return 1 < t && (n += e = Math.floor(t), t = t - e), {
+            raw: [ r + n + osc.SECS_70YRS, Math.round(osc.TWO_32 * t) ]
         };
     }, osc.ntpToJSTime = function(e, t) {
         return 1e3 * (e - osc.SECS_70YRS + t / osc.TWO_32);
     }, osc.jsToNTPTime = function(e) {
-        var t = e / 1e3, e = Math.floor(t);
-        return [ e + osc.SECS_70YRS, Math.round(osc.TWO_32 * (t - e)) ];
+        var e = e / 1e3, t = Math.floor(e);
+        return [ t + osc.SECS_70YRS, Math.round(osc.TWO_32 * (e - t)) ];
     }, osc.readArguments = function(e, t, r) {
         var n = osc.readString(e, r);
         if (0 !== n.indexOf(",")) throw new Error("A malformed type tag string was found while reading the arguments of an OSC message. String was: " + n, " at offset: " + r.idx);
@@ -158,26 +154,26 @@ var osc = osc || {};
     }, osc.readArgument = function(e, t, r, n, i) {
         var s = osc.argumentTypes[e];
         if (!s) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + t);
-        s = s.reader, i = osc[s](r, i);
-        return i = n.metadata ? {
+        t = s.reader, s = osc[t](r, i);
+        return s = n.metadata ? {
             type: e,
-            value: i
-        } : i;
+            value: s
+        } : s;
     }, osc.readArgumentsIntoArray = function(e, t, r, n, i, s) {
         for (var o = 0; o < t.length; ) {
             var c = t[o];
             if ("[" === c) {
                 var a = t.slice(o + 1), u = a.indexOf("]");
                 if (u < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + r);
-                var a = a.slice(0, u), a = osc.readArgumentsIntoArray([], a, r, n, i, s);
+                a = a.slice(0, u), a = osc.readArgumentsIntoArray([], a, r, n, i, s);
                 o += u + 2;
             } else a = osc.readArgument(c, r, n, i, s), o++;
             e.push(a);
         }
         return e;
     }, osc.writeArguments = function(e, t) {
-        t = osc.collectArguments(e, t);
-        return osc.joinParts(t);
+        e = osc.collectArguments(e, t);
+        return osc.joinParts(e);
     }, osc.joinParts = function(e) {
         for (var t = new Uint8Array(e.byteLength), r = e.parts, n = 0, i = 0; i < r.length; i++) {
             var s = r[i];
@@ -201,24 +197,24 @@ var osc = osc || {};
             byteLength: 0,
             parts: []
         }, t.metadata || (e = osc.annotateArguments(e));
-        for (var n = ",", i = r.parts.length, s = 0; s < e.length; s++) {
-            var o = e[s];
-            n += osc.writeArgument(o, r);
+        for (var n = ",", t = r.parts.length, i = 0; i < e.length; i++) {
+            var s = e[i];
+            n += osc.writeArgument(s, r);
         }
-        t = osc.writeString(n);
-        return r.byteLength += t.byteLength, r.parts.splice(i, 0, t), r;
+        var o = osc.writeString(n);
+        return r.byteLength += o.byteLength, r.parts.splice(t, 0, o), r;
     }, osc.readMessage = function(e, t, r) {
         t = t || osc.defaults;
-        var n = osc.dataView(e, e.byteOffset, e.byteLength), e = osc.readString(n, r = r || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), n = osc.readString(e, r = r || {
             idx: 0
         });
-        return osc.readMessageContents(e, n, t, r);
+        return osc.readMessageContents(n, e, t, r);
     }, osc.readMessageContents = function(e, t, r, n) {
         if (0 !== e.indexOf("/")) throw new Error("A malformed OSC address was found while reading an OSC message. String was: " + e);
-        n = osc.readArguments(t, r, n);
+        t = osc.readArguments(t, r, n);
         return {
             address: e,
-            args: 1 === n.length && r.unpackSingleArgs ? n[0] : n
+            args: 1 === t.length && r.unpackSingleArgs ? t[0] : t
         };
     }, osc.collectMessageParts = function(e, t, r) {
         return r = r || {
@@ -227,8 +223,8 @@ var osc = osc || {};
         }, osc.addDataPart(osc.writeString(e.address), r), osc.collectArguments(e.args, t, r);
     }, osc.writeMessage = function(e, t) {
         if (t = t || osc.defaults, !osc.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
-        t = osc.collectMessageParts(e, t);
-        return osc.joinParts(t);
+        e = osc.collectMessageParts(e, t);
+        return osc.joinParts(e);
     }, osc.isValidMessage = function(e) {
         return e.address && 0 === e.address.indexOf("/");
     }, osc.readBundle = function(e, t, r) {
@@ -247,8 +243,8 @@ var osc = osc || {};
     }, osc.writeBundle = function(e, t) {
         if (!osc.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
         t = t || osc.defaults;
-        t = osc.collectBundlePackets(e, t);
-        return osc.joinParts(t);
+        e = osc.collectBundlePackets(e, t);
+        return osc.joinParts(e);
     }, osc.isValidBundle = function(e) {
         return void 0 !== e.timeTag && void 0 !== e.packets;
     }, osc.readBundleContents = function(e, t, r, n) {
@@ -261,14 +257,13 @@ var osc = osc || {};
             packets: s
         };
     }, osc.readPacket = function(e, t, r, n) {
-        var i = osc.dataView(e, e.byteOffset, e.byteLength);
-        n = void 0 === n ? i.byteLength : n;
-        var s = osc.readString(i, r = r || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), i = (n = void 0 === n ? e.byteLength : n, 
+        osc.readString(e, r = r || {
             idx: 0
-        }), e = s[0];
-        if ("#" === e) return osc.readBundleContents(i, t, r, n);
-        if ("/" === e) return osc.readMessageContents(s, i, t, r);
-        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + s);
+        })), s = i[0];
+        if ("#" === s) return osc.readBundleContents(e, t, r, n);
+        if ("/" === s) return osc.readMessageContents(i, e, t, r);
+        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + i);
     }, osc.writePacket = function(e, t) {
         if (osc.isValidMessage(e)) return osc.writeMessage(e, t);
         if (osc.isValidBundle(e)) return osc.writeBundle(e, t);
@@ -360,7 +355,7 @@ var osc = osc || {};
         }
         return t;
     }, osc.isCommonJS && (module.exports = osc);
-}(), function(e, t) {
+}(), !function(e, t) {
     "object" == typeof exports && "object" == typeof module ? module.exports = t() : "function" == typeof define && define.amd ? define([], t) : "object" == typeof exports ? exports.Long = t() : e.Long = t();
 }("undefined" != typeof self ? self : this, function() {
     return r = [ function(e, t) {
@@ -414,27 +409,12 @@ var osc = osc || {};
         Object.defineProperty(n.prototype, "__isLong__", {
             value: !0
         }), n.isLong = d;
-        var s = {}, o = {};
-        n.fromInt = r, n.fromNumber = l, n.fromBits = g;
-        var h = Math.pow;
-        n.fromString = u, n.fromValue = p;
-        var i = 4294967296, c = i * i, a = c / 2, w = r(1 << 24), y = r(0);
-        n.ZERO = y;
-        var f = r(0, !0);
-        n.UZERO = f;
-        var v = r(1);
-        n.ONE = v;
-        var b = r(1, !0);
-        n.UONE = b;
-        var S = r(-1);
-        n.NEG_ONE = S;
-        var E = g(-1, 2147483647, !1);
-        n.MAX_VALUE = E;
-        var P = g(-1, -1, !0);
-        n.MAX_UNSIGNED_VALUE = P;
-        var A = g(0, -2147483648, !1);
-        n.MIN_VALUE = A;
-        var T = n.prototype;
+        var s = {}, o = {}, h = (n.fromInt = r, n.fromNumber = l, n.fromBits = g, 
+        Math.pow), i = (n.fromString = u, n.fromValue = p, 4294967296), c = i * i, a = c / 2, w = r(1 << 24), y = r(0), f = (n.ZERO = y, 
+        r(0, !0)), v = (n.UZERO = f, r(1)), b = (n.ONE = v, r(1, !0)), S = (n.UONE = b, 
+        r(-1)), E = (n.NEG_ONE = S, g(-1, 2147483647, !1)), P = (n.MAX_VALUE = E, 
+        g(-1, -1, !0)), A = (n.MAX_UNSIGNED_VALUE = P, g(0, -2147483648, !1)), T = (n.MIN_VALUE = A, 
+        n.prototype);
         T.toInt = function() {
             return this.unsigned ? this.low >>> 0 : this.low;
         }, T.toNumber = function() {
@@ -442,13 +422,9 @@ var osc = osc || {};
         }, T.toString = function(e) {
             if ((e = e || 10) < 2 || 36 < e) throw RangeError("radix");
             if (this.isZero()) return "0";
-            if (this.isNegative()) {
-                if (this.eq(A)) {
-                    var t = l(e), r = this.div(t), t = r.mul(t).sub(this);
-                    return r.toString(e) + t.toInt().toString(e);
-                }
-                return "-" + this.neg().toString(e);
-            }
+            var t, r;
+            if (this.isNegative()) return this.eq(A) ? (r = l(e), r = (t = this.div(r)).mul(r).sub(this), 
+            t.toString(e) + r.toInt().toString(e)) : "-" + this.neg().toString(e);
             for (var n = l(h(e, 6), this.unsigned), i = this, s = ""; ;) {
                 var o = i.div(n), c = (i.sub(o.mul(n)).toInt() >>> 0).toString(e);
                 if ((i = o).isZero()) return c + s;
@@ -465,7 +441,7 @@ var osc = osc || {};
             return this.low >>> 0;
         }, T.getNumBitsAbs = function() {
             if (this.isNegative()) return this.eq(A) ? 64 : this.neg().getNumBitsAbs();
-            for (var e = 0 != this.high ? this.high : this.low, t = 31; 0 < t && 0 == (e & 1 << t); t--) ;
+            for (var e = 0 != this.high ? this.high : this.low, t = 31; 0 < t && 0 == (e & 1 << t); t--);
             return 0 != this.high ? t + 33 : t + 1;
         }, T.isZero = function() {
             return 0 === this.high && 0 === this.low;
@@ -498,8 +474,8 @@ var osc = osc || {};
         }, T.neg = T.negate, T.add = function(e) {
             d(e) || (e = p(e));
             var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, c = e.low >>> 16, a = 0, u = 0, h = 0, f = 0;
-            return h += (f += i + (65535 & e.low)) >>> 16, u += (h += n + c) >>> 16, a += (u += r + o) >>> 16, 
-            a += t + s, g((h &= 65535) << 16 | (f &= 65535), (a &= 65535) << 16 | (u &= 65535), this.unsigned);
+            return u += (h = h + ((f += i + (65535 & e.low)) >>> 16) + (n + c)) >>> 16, 
+            g((h &= 65535) << 16 | (f &= 65535), ((a += (u += r + o) >>> 16) + (t + s) & 65535) << 16 | (u &= 65535), this.unsigned);
         }, T.subtract = function(e) {
             return d(e) || (e = p(e)), this.add(e.neg());
         }, T.sub = T.subtract, T.multiply = function(e) {
@@ -511,17 +487,15 @@ var osc = osc || {};
             if (this.isNegative()) return e.isNegative() ? this.neg().mul(e.neg()) : this.neg().mul(e).neg();
             if (e.isNegative()) return this.mul(e.neg()).neg();
             if (this.lt(w) && e.lt(w)) return l(this.toNumber() * e.toNumber(), this.unsigned);
-            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, c = e.low >>> 16, a = 65535 & e.low, u = 0, h = 0, f = 0, e = 0;
-            return f += (e += i * a) >>> 16, h += (f += n * a) >>> 16, f &= 65535, h += (f += i * c) >>> 16, 
-            u += (h += r * a) >>> 16, h &= 65535, u += (h += n * c) >>> 16, h &= 65535, u += (h += i * o) >>> 16, 
-            u += t * a + r * c + n * o + i * s, g((f &= 65535) << 16 | (e &= 65535), (u &= 65535) << 16 | (h &= 65535), this.unsigned);
+            var t = this.high >>> 16, r = 65535 & this.high, n = this.low >>> 16, i = 65535 & this.low, s = e.high >>> 16, o = 65535 & e.high, c = e.low >>> 16, e = 65535 & e.low, a = 0, u = 0, h = 0, f = (f = 0) + ((u = u + ((h += i * e) >>> 16) + n * e) >>> 16) + ((u = (u & 65535) + i * c) >>> 16);
+            return g((u &= 65535) << 16 | (h &= 65535), ((a += (f += r * e) >>> 16) + ((f = (f & 65535) + n * c) >>> 16) + ((f = (f & 65535) + i * o) >>> 16) + (t * e + r * c + n * o + i * s) & 65535) << 16 | (f &= 65535), this.unsigned);
         }, T.mul = T.multiply, T.divide = function(e) {
-            if ((e = !d(e) ? p(e) : e).isZero()) throw Error("division by zero");
+            if ((e = d(e) ? e : p(e)).isZero()) throw Error("division by zero");
             if (m) return this.unsigned || -2147483648 !== this.high || -1 !== e.low || -1 !== e.high ? g((this.unsigned ? m.div_u : m.div_s)(this.low, this.high, e.low, e.high), m.get_high(), this.unsigned) : this;
             if (this.isZero()) return this.unsigned ? f : y;
             var t, r;
             if (this.unsigned) {
-                if ((e = !e.unsigned ? e.toUnsigned() : e).gt(this)) return f;
+                if ((e = e.unsigned ? e : e.toUnsigned()).gt(this)) return f;
                 if (e.gt(this.shru(1))) return b;
                 r = f;
             } else {
@@ -600,22 +574,22 @@ var osc = osc || {};
         return r[e].call(t.exports, t, t.exports, n), t.l = !0, t.exports;
     }
     var r, i;
-}), function(t, r) {
+}), !function(t, r) {
     "use strict";
     "object" == typeof exports ? (t.slip = exports, r(exports)) : "function" == typeof define && define.amd ? define([ "exports" ], function(e) {
         return t.slip = e, t.slip, r(e);
     }) : (t.slip = {}, r(t.slip));
 }(this, function(e) {
     "use strict";
-    var o = e;
-    o.END = 192, o.ESC = 219, o.ESC_END = 220, o.ESC_ESC = 221, o.byteArray = function(e, t, r) {
+    var o = e, e = (o.END = 192, o.ESC = 219, o.ESC_END = 220, o.ESC_ESC = 221, 
+    o.byteArray = function(e, t, r) {
         return e instanceof ArrayBuffer ? new Uint8Array(e, t, r) : e;
     }, o.expandByteArray = function(e) {
         var t = new Uint8Array(2 * e.length);
         return t.set(e), t;
     }, o.sliceByteArray = function(e, t, r) {
-        r = e.buffer.slice ? e.buffer.slice(t, r) : e.subarray(t, r);
-        return new Uint8Array(r);
+        e = e.buffer.slice ? e.buffer.slice(t, r) : e.subarray(t, r);
+        return new Uint8Array(e);
     }, o.encode = function(e, t) {
         (t = t || {}).bufferPadding = t.bufferPadding || 4;
         var t = (e = o.byteArray(e, t.offset, t.byteLength)).length + t.bufferPadding + 3 & -4, r = new Uint8Array(t), n = 1;
@@ -631,9 +605,9 @@ var osc = osc || {};
         this.maxMessageSize = (e = "function" != typeof e ? e || {} : {
             onMessage: e
         }).maxMessageSize || 10485760, this.bufferSize = e.bufferSize || 1024, this.msgBuffer = new Uint8Array(this.bufferSize), 
-        this.msgBufferIdx = 0, this.onMessage = e.onMessage, this.onError = e.onError, this.escape = !1;
-    };
-    e = o.Decoder.prototype;
+        this.msgBufferIdx = 0, this.onMessage = e.onMessage, this.onError = e.onError, 
+        this.escape = !1;
+    }, o.Decoder.prototype);
     return e.decode = function(e) {
         var t;
         e = o.byteArray(e);
@@ -659,12 +633,11 @@ var osc = osc || {};
         return this.msgBufferIdx > this.msgBuffer.length - 1 && (this.msgBuffer = o.expandByteArray(this.msgBuffer)), 
         this.msgBuffer[this.msgBufferIdx++] = e, this.escape = !1, this.msgBuffer.length < this.maxMessageSize;
     }, e.handleEnd = function() {
-        if (0 !== this.msgBufferIdx) {
-            var e = o.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx);
-            return this.onMessage && this.onMessage(e), this.msgBufferIdx = 0, e;
-        }
+        var e;
+        if (0 !== this.msgBufferIdx) return e = o.sliceByteArray(this.msgBuffer, 0, this.msgBufferIdx), 
+        this.onMessage && this.onMessage(e), this.msgBufferIdx = 0, e;
     }, o;
-}), function(e) {
+}), !function(e) {
     "use strict";
     function t() {}
     var r = t.prototype, n = e.EventEmitter;
@@ -742,11 +715,7 @@ var osc = osc || {};
     }, "function" == typeof define && define.amd ? define(function() {
         return t;
     }) : "object" == typeof module && module.exports ? module.exports = t : e.EventEmitter = t;
-}("undefined" != typeof window ? window : this || {});
-
-var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitter = EventEmitter || require("events").EventEmitter;
-
-!function() {
+}("undefined" != typeof window ? window : this || {}), osc || require("./osc.js")), slip = slip || require("slip"), EventEmitter = EventEmitter || require("events").EventEmitter, osc = (!function() {
     "use strict";
     osc.supportsSerial = !1, osc.firePacketEvents = function(e, t, r, n) {
         t.address ? e.emit("message", t, r, n) : osc.fireBundleEvents(e, t, r, n);
@@ -783,14 +752,13 @@ var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitt
             this.emit("error", e);
         }
     }, osc.SLIPPort = function(e) {
-        var t = this, e = this.options = e || {};
-        e.useSLIP = void 0 === e.useSLIP || e.useSLIP, this.decoder = new slip.Decoder({
+        var t = this, e = this.options = e || {}, e = (e.useSLIP = void 0 === e.useSLIP || e.useSLIP, 
+        this.decoder = new slip.Decoder({
             onMessage: this.decodeOSC.bind(this),
             onError: function(e) {
                 t.emit("error", e);
             }
-        });
-        e = e.useSLIP ? this.decodeSLIPData : this.decodeOSC;
+        }), e.useSLIP ? this.decodeSLIPData : this.decodeOSC);
         this.on("data", e.bind(this));
     }, (e = osc.SLIPPort.prototype = Object.create(osc.Port.prototype)).constructor = osc.SLIPPort, 
     e.encodeOSC = function(e) {
@@ -831,13 +799,10 @@ var osc = osc || require("./osc.js"), slip = slip || require("slip"), EventEmitt
         osc.stopRelaying(this.port1, this.port1Spec), osc.stopRelaying(this.port2, this.port2Spec), 
         this.emit("close", this.port1, this.port2);
     }, "undefined" != typeof module && module.exports && (module.exports = osc);
-}();
-
-osc = osc || require("./osc.js");
-
-!function() {
+}(), osc || require("./osc.js")), osc = (!function() {
     "use strict";
-    osc.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), osc.WebSocketPort = function(e) {
+    osc.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), 
+    osc.WebSocketPort = function(e) {
         osc.Port.call(this, e), this.on("open", this.listen.bind(this)), this.socket = e.socket, 
         this.socket && (1 === this.socket.readyState ? (osc.WebSocketPort.setupSocketForBinary(this.socket), 
         this.emit("open", this.socket)) : this.open());
@@ -866,9 +831,7 @@ osc = osc || require("./osc.js");
     }, osc.WebSocketPort.setupSocketForBinary = function(e) {
         e.binaryType = osc.isNode ? "nodebuffer" : "arraybuffer";
     };
-}();
-
-osc = osc || {};
+}(), osc || {});
 
 !function() {
     "use strict";

--- a/dist/osc-module.js
+++ b/dist/osc-module.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 
 (function (root, factory) {
     if (typeof exports === "object") {

--- a/dist/osc-module.min.js
+++ b/dist/osc-module.min.js
@@ -1,13 +1,10 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
-
-
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 !function(i, o) {
     "object" == typeof exports ? (i.osc = exports, o(0, require("slip"), require("EventEmitter"), require("long"))) : "function" == typeof define && define.amd ? define([ "exports", "slip", "EventEmitter", "long" ], function(e, t, r, n) {
         return i.osc = e, i.osc, o(0, t, r, n);
     }) : (i.osc = {}, o(i.osc, slip, EventEmitter));
 }(this, function(e, n, t, r) {
-    var c = c || {};
-    !function() {
+    var c = c || {}, c = (!function() {
         "use strict";
         c.SECS_70YRS = 2208988800, c.TWO_32 = 4294967296, c.defaults = {
             metadata: !1,
@@ -27,8 +24,8 @@
         }, c.byteArray = function(e) {
             if (e instanceof Uint8Array) return e;
             var t = e.buffer || e;
-            if (!(t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
-            return new Uint8Array(t);
+            if (t instanceof ArrayBuffer || void 0 !== t.length && "string" != typeof t) return new Uint8Array(t);
+            throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
         }, c.nativeBuffer = function(e) {
             return c.isBufferEnv ? c.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : c.isTypedArrayView(e) ? e : new Uint8Array(e);
         }, c.copyByteArray = function(e, t, r) {
@@ -66,8 +63,8 @@
         }, c.writeString.withBuffer = function(e) {
             return Buffer.from(e);
         }, c.readPrimitive = function(e, t, r, n) {
-            t = e[t](n.idx, !1);
-            return n.idx += r, t;
+            e = e[t](n.idx, !1);
+            return n.idx += r, e;
         }, c.writePrimitive = function(e, t, r, n, i) {
             var o;
             return i = void 0 === i ? 0 : i, t ? o = new Uint8Array(t.buffer) : (o = new Uint8Array(n), 
@@ -77,10 +74,10 @@
         }, c.writeInt32 = function(e, t, r) {
             return c.writePrimitive(e, t, "setInt32", 4, r);
         }, c.readInt64 = function(e, t) {
-            var r = c.readPrimitive(e, "getInt32", 4, t), t = c.readPrimitive(e, "getInt32", 4, t);
-            return c.Long ? new c.Long(t, r) : {
+            var r = c.readPrimitive(e, "getInt32", 4, t), e = c.readPrimitive(e, "getInt32", 4, t);
+            return c.Long ? new c.Long(e, r) : {
                 high: r,
-                low: t,
+                low: e,
                 unsigned: !1
             };
         }, c.writeInt64 = function(e, t, r) {
@@ -96,14 +93,14 @@
         }, c.writeFloat64 = function(e, t, r) {
             return c.writePrimitive(e, t, "setFloat64", 8, r);
         }, c.readChar32 = function(e, t) {
-            t = c.readPrimitive(e, "getUint32", 4, t);
-            return String.fromCharCode(t);
+            e = c.readPrimitive(e, "getUint32", 4, t);
+            return String.fromCharCode(e);
         }, c.writeChar32 = function(e, t, r) {
             e = e.charCodeAt(0);
             if (!(void 0 === e || e < -1)) return c.writePrimitive(e, t, "setUint32", 4, r);
         }, c.readBlob = function(e, t) {
-            var r = c.readInt32(e, t), n = r + 3 & -4, r = new Uint8Array(e.buffer, t.idx, r);
-            return t.idx += n, r;
+            var r = c.readInt32(e, t), n = r + 3 & -4, e = new Uint8Array(e.buffer, t.idx, r);
+            return t.idx += n, e;
         }, c.writeBlob = function(e) {
             var t = (e = c.byteArray(e)).byteLength, r = new Uint8Array(4 + (t + 3 & -4)), n = new DataView(r.buffer);
             return c.writeInt32(t, n), r.set(e, 4), r;
@@ -115,12 +112,12 @@
             var t = new Uint8Array(4);
             return t.set(e), t;
         }, c.readColor = function(e, t) {
-            var r = new Uint8Array(e.buffer, t.idx, 4), e = r[3] / 255;
+            var e = new Uint8Array(e.buffer, t.idx, 4), r = e[3] / 255;
             return t.idx += 4, {
-                r: r[0],
-                g: r[1],
-                b: r[2],
-                a: e
+                r: e[0],
+                g: e[1],
+                b: e[2],
+                a: r
             };
         }, c.writeColor = function(e) {
             var t = Math.round(255 * e.a);
@@ -134,25 +131,25 @@
         }, c.readImpulse = function() {
             return 1;
         }, c.readTimeTag = function(e, t) {
-            var r = c.readPrimitive(e, "getUint32", 4, t), t = c.readPrimitive(e, "getUint32", 4, t);
+            var r = c.readPrimitive(e, "getUint32", 4, t), e = c.readPrimitive(e, "getUint32", 4, t);
             return {
-                raw: [ r, t ],
-                native: 0 === r && 1 === t ? Date.now() : c.ntpToJSTime(r, t)
+                raw: [ r, e ],
+                native: 0 === r && 1 === e ? Date.now() : c.ntpToJSTime(r, e)
             };
         }, c.writeTimeTag = function(e) {
-            var t = e.raw || c.jsToNTPTime(e.native), r = new Uint8Array(8), e = new DataView(r.buffer);
-            return c.writeInt32(t[0], e, 0), c.writeInt32(t[1], e, 4), r;
+            var e = e.raw || c.jsToNTPTime(e.native), t = new Uint8Array(8), r = new DataView(t.buffer);
+            return c.writeInt32(e[0], r, 0), c.writeInt32(e[1], r, 4), t;
         }, c.timeTag = function(e, t) {
             e = e || 0;
-            var r = (t = t || Date.now()) / 1e3, n = Math.floor(r), t = r - n, r = Math.floor(e), t = t + (e - r);
-            return 1 < t && (r += e = Math.floor(t), t = t - e), {
-                raw: [ n + r + c.SECS_70YRS, Math.round(c.TWO_32 * t) ]
+            var t = (t = t || Date.now()) / 1e3, r = Math.floor(t), t = t - r, n = Math.floor(e), t = t + (e - n);
+            return 1 < t && (n += e = Math.floor(t), t = t - e), {
+                raw: [ r + n + c.SECS_70YRS, Math.round(c.TWO_32 * t) ]
             };
         }, c.ntpToJSTime = function(e, t) {
             return 1e3 * (e - c.SECS_70YRS + t / c.TWO_32);
         }, c.jsToNTPTime = function(e) {
-            var t = e / 1e3, e = Math.floor(t);
-            return [ e + c.SECS_70YRS, Math.round(c.TWO_32 * (t - e)) ];
+            var e = e / 1e3, t = Math.floor(e);
+            return [ t + c.SECS_70YRS, Math.round(c.TWO_32 * (e - t)) ];
         }, c.readArguments = function(e, t, r) {
             var n = c.readString(e, r);
             if (0 !== n.indexOf(",")) throw new Error("A malformed type tag string was found while reading the arguments of an OSC message. String was: " + n, " at offset: " + r.idx);
@@ -161,26 +158,26 @@
         }, c.readArgument = function(e, t, r, n, i) {
             var o = c.argumentTypes[e];
             if (!o) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + t);
-            o = o.reader, i = c[o](r, i);
-            return i = n.metadata ? {
+            t = o.reader, o = c[t](r, i);
+            return o = n.metadata ? {
                 type: e,
-                value: i
-            } : i;
+                value: o
+            } : o;
         }, c.readArgumentsIntoArray = function(e, t, r, n, i, o) {
             for (var a = 0; a < t.length; ) {
                 var s = t[a];
                 if ("[" === s) {
                     var u = t.slice(a + 1), d = u.indexOf("]");
                     if (d < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + r);
-                    var u = u.slice(0, d), u = c.readArgumentsIntoArray([], u, r, n, i, o);
+                    u = u.slice(0, d), u = c.readArgumentsIntoArray([], u, r, n, i, o);
                     a += d + 2;
                 } else u = c.readArgument(s, r, n, i, o), a++;
                 e.push(u);
             }
             return e;
         }, c.writeArguments = function(e, t) {
-            t = c.collectArguments(e, t);
-            return c.joinParts(t);
+            e = c.collectArguments(e, t);
+            return c.joinParts(e);
         }, c.joinParts = function(e) {
             for (var t = new Uint8Array(e.byteLength), r = e.parts, n = 0, i = 0; i < r.length; i++) {
                 var o = r[i];
@@ -204,24 +201,24 @@
                 byteLength: 0,
                 parts: []
             }, t.metadata || (e = c.annotateArguments(e));
-            for (var n = ",", i = r.parts.length, o = 0; o < e.length; o++) {
-                var a = e[o];
-                n += c.writeArgument(a, r);
+            for (var n = ",", t = r.parts.length, i = 0; i < e.length; i++) {
+                var o = e[i];
+                n += c.writeArgument(o, r);
             }
-            t = c.writeString(n);
-            return r.byteLength += t.byteLength, r.parts.splice(i, 0, t), r;
+            var a = c.writeString(n);
+            return r.byteLength += a.byteLength, r.parts.splice(t, 0, a), r;
         }, c.readMessage = function(e, t, r) {
             t = t || c.defaults;
-            var n = c.dataView(e, e.byteOffset, e.byteLength), e = c.readString(n, r = r || {
+            var e = c.dataView(e, e.byteOffset, e.byteLength), n = c.readString(e, r = r || {
                 idx: 0
             });
-            return c.readMessageContents(e, n, t, r);
+            return c.readMessageContents(n, e, t, r);
         }, c.readMessageContents = function(e, t, r, n) {
             if (0 !== e.indexOf("/")) throw new Error("A malformed OSC address was found while reading an OSC message. String was: " + e);
-            n = c.readArguments(t, r, n);
+            t = c.readArguments(t, r, n);
             return {
                 address: e,
-                args: 1 === n.length && r.unpackSingleArgs ? n[0] : n
+                args: 1 === t.length && r.unpackSingleArgs ? t[0] : t
             };
         }, c.collectMessageParts = function(e, t, r) {
             return r = r || {
@@ -230,8 +227,8 @@
             }, c.addDataPart(c.writeString(e.address), r), c.collectArguments(e.args, t, r);
         }, c.writeMessage = function(e, t) {
             if (t = t || c.defaults, !c.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
-            t = c.collectMessageParts(e, t);
-            return c.joinParts(t);
+            e = c.collectMessageParts(e, t);
+            return c.joinParts(e);
         }, c.isValidMessage = function(e) {
             return e.address && 0 === e.address.indexOf("/");
         }, c.readBundle = function(e, t, r) {
@@ -243,14 +240,15 @@
             }, c.addDataPart(c.writeString("#bundle"), r), c.addDataPart(c.writeTimeTag(e.timeTag), r);
             for (var n = 0; n < e.packets.length; n++) {
                 var i = e.packets[n], i = (i.address ? c.collectMessageParts : c.collectBundlePackets)(i, t);
-                r.byteLength += i.byteLength, c.addDataPart(c.writeInt32(i.byteLength), r), r.parts = r.parts.concat(i.parts);
+                r.byteLength += i.byteLength, c.addDataPart(c.writeInt32(i.byteLength), r), 
+                r.parts = r.parts.concat(i.parts);
             }
             return r;
         }, c.writeBundle = function(e, t) {
             if (!c.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
             t = t || c.defaults;
-            t = c.collectBundlePackets(e, t);
-            return c.joinParts(t);
+            e = c.collectBundlePackets(e, t);
+            return c.joinParts(e);
         }, c.isValidBundle = function(e) {
             return void 0 !== e.timeTag && void 0 !== e.packets;
         }, c.readBundleContents = function(e, t, r, n) {
@@ -263,14 +261,13 @@
                 packets: o
             };
         }, c.readPacket = function(e, t, r, n) {
-            var i = c.dataView(e, e.byteOffset, e.byteLength);
-            n = void 0 === n ? i.byteLength : n;
-            var o = c.readString(i, r = r || {
+            var e = c.dataView(e, e.byteOffset, e.byteLength), i = (n = void 0 === n ? e.byteLength : n, 
+            c.readString(e, r = r || {
                 idx: 0
-            }), e = o[0];
-            if ("#" === e) return c.readBundleContents(i, t, r, n);
-            if ("/" === e) return c.readMessageContents(o, i, t, r);
-            throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + o);
+            })), o = i[0];
+            if ("#" === o) return c.readBundleContents(e, t, r, n);
+            if ("/" === o) return c.readMessageContents(i, e, t, r);
+            throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + i);
         }, c.writePacket = function(e, t) {
             if (c.isValidMessage(e)) return c.writeMessage(e, t);
             if (c.isValidBundle(e)) return c.writeBundle(e, t);
@@ -362,9 +359,7 @@
             }
             return t;
         }, c.isCommonJS && (module.exports = c);
-    }();
-    c = c || require("./osc.js"), n = n || require("slip"), t = t || require("events").EventEmitter;
-    !function() {
+    }(), c || require("./osc.js")), n = n || require("slip"), t = t || require("events").EventEmitter, c = (!function() {
         "use strict";
         c.supportsSerial = !1, c.firePacketEvents = function(e, t, r, n) {
             t.address ? e.emit("message", t, r, n) : c.fireBundleEvents(e, t, r, n);
@@ -401,14 +396,13 @@
                 this.emit("error", e);
             }
         }, c.SLIPPort = function(e) {
-            var t = this, e = this.options = e || {};
-            e.useSLIP = void 0 === e.useSLIP || e.useSLIP, this.decoder = new n.Decoder({
+            var t = this, e = this.options = e || {}, e = (e.useSLIP = void 0 === e.useSLIP || e.useSLIP, 
+            this.decoder = new n.Decoder({
                 onMessage: this.decodeOSC.bind(this),
                 onError: function(e) {
                     t.emit("error", e);
                 }
-            });
-            e = e.useSLIP ? this.decodeSLIPData : this.decodeOSC;
+            }), e.useSLIP ? this.decodeSLIPData : this.decodeOSC);
             this.on("data", e.bind(this));
         }, (e = c.SLIPPort.prototype = Object.create(c.Port.prototype)).constructor = c.SLIPPort, 
         e.encodeOSC = function(e) {
@@ -437,7 +431,8 @@
             e.removeListener(t.eventName, t.listener);
         }, c.Relay = function(e, t, r) {
             (this.options = r || {}).raw = !1, this.port1 = e, this.port2 = t, this.listen();
-        }, (e = c.Relay.prototype = Object.create(t.prototype)).constructor = c.Relay, e.open = function() {
+        }, (e = c.Relay.prototype = Object.create(t.prototype)).constructor = c.Relay, 
+        e.open = function() {
             this.port1.open(), this.port2.open();
         }, e.listen = function() {
             this.port1Spec && this.port2Spec && this.close(), this.port1Spec = c.relayPorts(this.port1, this.port2, this.options), 
@@ -448,11 +443,11 @@
             c.stopRelaying(this.port1, this.port1Spec), c.stopRelaying(this.port2, this.port2Spec), 
             this.emit("close", this.port1, this.port2);
         }, "undefined" != typeof module && module.exports && (module.exports = c);
-    }();
-    c = c || require("./osc.js");
+    }(), c || require("./osc.js"));
     return function() {
         "use strict";
-        c.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), c.WebSocketPort = function(e) {
+        c.WebSocket = "undefined" != typeof WebSocket ? WebSocket : require("ws"), 
+        c.WebSocketPort = function(e) {
             c.Port.call(this, e), this.on("open", this.listen.bind(this)), this.socket = e.socket, 
             this.socket && (1 === this.socket.readyState ? (c.WebSocketPort.setupSocketForBinary(this.socket), 
             this.emit("open", this.socket)) : this.open());

--- a/dist/osc.js
+++ b/dist/osc.js
@@ -1,4 +1,4 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 
 /*
  * osc.js: An Open Sound Control library for JavaScript that works in both the browser and Node.js

--- a/dist/osc.min.js
+++ b/dist/osc.min.js
@@ -1,6 +1,4 @@
-/*! osc.js 2.4.1, Copyright 2021 Colin Clark | github.com/colinbdclark/osc.js */
-
-
+/*! osc.js 2.4.2, Copyright 2022 Colin Clark | github.com/colinbdclark/osc.js */
 var osc = osc || {};
 
 !function() {
@@ -24,13 +22,13 @@ var osc = osc || {};
     }, osc.byteArray = function(e) {
         if (e instanceof Uint8Array) return e;
         var r = e.buffer || e;
-        if (!(r instanceof ArrayBuffer || void 0 !== r.length && "string" != typeof r)) throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
-        return new Uint8Array(r);
+        if (r instanceof ArrayBuffer || void 0 !== r.length && "string" != typeof r) return new Uint8Array(r);
+        throw new Error("Can't wrap a non-array-like object as Uint8Array. Object was: " + JSON.stringify(e, null, 2));
     }, osc.nativeBuffer = function(e) {
         return osc.isBufferEnv ? osc.isBuffer(e) ? e : Buffer.from(e.buffer ? e : new Uint8Array(e)) : osc.isTypedArrayView(e) ? e : new Uint8Array(e);
     }, osc.copyByteArray = function(e, r, t) {
-        if (osc.isTypedArrayView(e) && osc.isTypedArrayView(r)) r.set(e, t); else for (var n = void 0 === t ? 0 : t, o = Math.min(r.length - t, e.length), a = 0, i = n; a < o; a++, 
-        i++) r[i] = e[a];
+        if (osc.isTypedArrayView(e) && osc.isTypedArrayView(r)) r.set(e, t); else for (var n = void 0 === t ? 0 : t, o = Math.min(r.length - t, e.length), i = 0, a = n; i < o; i++, 
+        a++) r[a] = e[i];
         return r;
     }, osc.readString = function(e, r) {
         for (var t = [], n = r.idx; n < e.byteLength; n++) {
@@ -53,9 +51,9 @@ var osc = osc || {};
     }, osc.writeString = function(e) {
         var r, t = e + "\0", e = t.length, n = new Uint8Array(e + 3 & -4), o = osc.isBufferEnv ? osc.writeString.withBuffer : osc.TextEncoder ? osc.writeString.withTextEncoder : null;
         o && (r = o(t));
-        for (var a = 0; a < t.length; a++) {
-            var i = o ? r[a] : t.charCodeAt(a);
-            n[a] = i;
+        for (var i = 0; i < t.length; i++) {
+            var a = o ? r[i] : t.charCodeAt(i);
+            n[i] = a;
         }
         return n;
     }, osc.writeString.withTextEncoder = function(e) {
@@ -63,21 +61,21 @@ var osc = osc || {};
     }, osc.writeString.withBuffer = function(e) {
         return Buffer.from(e);
     }, osc.readPrimitive = function(e, r, t, n) {
-        r = e[r](n.idx, !1);
-        return n.idx += t, r;
+        e = e[r](n.idx, !1);
+        return n.idx += t, e;
     }, osc.writePrimitive = function(e, r, t, n, o) {
-        var a;
-        return o = void 0 === o ? 0 : o, r ? a = new Uint8Array(r.buffer) : (a = new Uint8Array(n), 
-        r = new DataView(a.buffer)), r[t](o, e, !1), a;
+        var i;
+        return o = void 0 === o ? 0 : o, r ? i = new Uint8Array(r.buffer) : (i = new Uint8Array(n), 
+        r = new DataView(i.buffer)), r[t](o, e, !1), i;
     }, osc.readInt32 = function(e, r) {
         return osc.readPrimitive(e, "getInt32", 4, r);
     }, osc.writeInt32 = function(e, r, t) {
         return osc.writePrimitive(e, r, "setInt32", 4, t);
     }, osc.readInt64 = function(e, r) {
-        var t = osc.readPrimitive(e, "getInt32", 4, r), r = osc.readPrimitive(e, "getInt32", 4, r);
-        return osc.Long ? new osc.Long(r, t) : {
+        var t = osc.readPrimitive(e, "getInt32", 4, r), e = osc.readPrimitive(e, "getInt32", 4, r);
+        return osc.Long ? new osc.Long(e, t) : {
             high: t,
-            low: r,
+            low: e,
             unsigned: !1
         };
     }, osc.writeInt64 = function(e, r, t) {
@@ -93,14 +91,14 @@ var osc = osc || {};
     }, osc.writeFloat64 = function(e, r, t) {
         return osc.writePrimitive(e, r, "setFloat64", 8, t);
     }, osc.readChar32 = function(e, r) {
-        r = osc.readPrimitive(e, "getUint32", 4, r);
-        return String.fromCharCode(r);
+        e = osc.readPrimitive(e, "getUint32", 4, r);
+        return String.fromCharCode(e);
     }, osc.writeChar32 = function(e, r, t) {
         e = e.charCodeAt(0);
         if (!(void 0 === e || e < -1)) return osc.writePrimitive(e, r, "setUint32", 4, t);
     }, osc.readBlob = function(e, r) {
-        var t = osc.readInt32(e, r), n = t + 3 & -4, t = new Uint8Array(e.buffer, r.idx, t);
-        return r.idx += n, t;
+        var t = osc.readInt32(e, r), n = t + 3 & -4, e = new Uint8Array(e.buffer, r.idx, t);
+        return r.idx += n, e;
     }, osc.writeBlob = function(e) {
         var r = (e = osc.byteArray(e)).byteLength, t = new Uint8Array(4 + (r + 3 & -4)), n = new DataView(t.buffer);
         return osc.writeInt32(r, n), t.set(e, 4), t;
@@ -112,12 +110,12 @@ var osc = osc || {};
         var r = new Uint8Array(4);
         return r.set(e), r;
     }, osc.readColor = function(e, r) {
-        var t = new Uint8Array(e.buffer, r.idx, 4), e = t[3] / 255;
+        var e = new Uint8Array(e.buffer, r.idx, 4), t = e[3] / 255;
         return r.idx += 4, {
-            r: t[0],
-            g: t[1],
-            b: t[2],
-            a: e
+            r: e[0],
+            g: e[1],
+            b: e[2],
+            a: t
         };
     }, osc.writeColor = function(e) {
         var r = Math.round(255 * e.a);
@@ -131,57 +129,57 @@ var osc = osc || {};
     }, osc.readImpulse = function() {
         return 1;
     }, osc.readTimeTag = function(e, r) {
-        var t = osc.readPrimitive(e, "getUint32", 4, r), r = osc.readPrimitive(e, "getUint32", 4, r);
+        var t = osc.readPrimitive(e, "getUint32", 4, r), e = osc.readPrimitive(e, "getUint32", 4, r);
         return {
-            raw: [ t, r ],
-            native: 0 === t && 1 === r ? Date.now() : osc.ntpToJSTime(t, r)
+            raw: [ t, e ],
+            native: 0 === t && 1 === e ? Date.now() : osc.ntpToJSTime(t, e)
         };
     }, osc.writeTimeTag = function(e) {
-        var r = e.raw || osc.jsToNTPTime(e.native), t = new Uint8Array(8), e = new DataView(t.buffer);
-        return osc.writeInt32(r[0], e, 0), osc.writeInt32(r[1], e, 4), t;
+        var e = e.raw || osc.jsToNTPTime(e.native), r = new Uint8Array(8), t = new DataView(r.buffer);
+        return osc.writeInt32(e[0], t, 0), osc.writeInt32(e[1], t, 4), r;
     }, osc.timeTag = function(e, r) {
         e = e || 0;
-        var t = (r = r || Date.now()) / 1e3, n = Math.floor(t), r = t - n, t = Math.floor(e), r = r + (e - t);
-        return 1 < r && (t += e = Math.floor(r), r = r - e), {
-            raw: [ n + t + osc.SECS_70YRS, Math.round(osc.TWO_32 * r) ]
+        var r = (r = r || Date.now()) / 1e3, t = Math.floor(r), r = r - t, n = Math.floor(e), r = r + (e - n);
+        return 1 < r && (n += e = Math.floor(r), r = r - e), {
+            raw: [ t + n + osc.SECS_70YRS, Math.round(osc.TWO_32 * r) ]
         };
     }, osc.ntpToJSTime = function(e, r) {
         return 1e3 * (e - osc.SECS_70YRS + r / osc.TWO_32);
     }, osc.jsToNTPTime = function(e) {
-        var r = e / 1e3, e = Math.floor(r);
-        return [ e + osc.SECS_70YRS, Math.round(osc.TWO_32 * (r - e)) ];
+        var e = e / 1e3, r = Math.floor(e);
+        return [ r + osc.SECS_70YRS, Math.round(osc.TWO_32 * (e - r)) ];
     }, osc.readArguments = function(e, r, t) {
         var n = osc.readString(e, t);
         if (0 !== n.indexOf(",")) throw new Error("A malformed type tag string was found while reading the arguments of an OSC message. String was: " + n, " at offset: " + t.idx);
-        var o = n.substring(1).split(""), a = [];
-        return osc.readArgumentsIntoArray(a, o, n, e, r, t), a;
+        var o = n.substring(1).split(""), i = [];
+        return osc.readArgumentsIntoArray(i, o, n, e, r, t), i;
     }, osc.readArgument = function(e, r, t, n, o) {
-        var a = osc.argumentTypes[e];
-        if (!a) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + r);
-        a = a.reader, o = osc[a](t, o);
-        return o = n.metadata ? {
+        var i = osc.argumentTypes[e];
+        if (!i) throw new Error("'" + e + "' is not a valid OSC type tag. Type tag string was: " + r);
+        r = i.reader, i = osc[r](t, o);
+        return i = n.metadata ? {
             type: e,
-            value: o
-        } : o;
-    }, osc.readArgumentsIntoArray = function(e, r, t, n, o, a) {
-        for (var i = 0; i < r.length; ) {
-            var s = r[i];
+            value: i
+        } : i;
+    }, osc.readArgumentsIntoArray = function(e, r, t, n, o, i) {
+        for (var a = 0; a < r.length; ) {
+            var s = r[a];
             if ("[" === s) {
-                var c = r.slice(i + 1), u = c.indexOf("]");
+                var c = r.slice(a + 1), u = c.indexOf("]");
                 if (u < 0) throw new Error("Invalid argument type tag: an open array type tag ('[') was found without a matching close array tag ('[]'). Type tag was: " + t);
-                var c = c.slice(0, u), c = osc.readArgumentsIntoArray([], c, t, n, o, a);
-                i += u + 2;
-            } else c = osc.readArgument(s, t, n, o, a), i++;
+                c = c.slice(0, u), c = osc.readArgumentsIntoArray([], c, t, n, o, i);
+                a += u + 2;
+            } else c = osc.readArgument(s, t, n, o, i), a++;
             e.push(c);
         }
         return e;
     }, osc.writeArguments = function(e, r) {
-        r = osc.collectArguments(e, r);
-        return osc.joinParts(r);
+        e = osc.collectArguments(e, r);
+        return osc.joinParts(e);
     }, osc.joinParts = function(e) {
         for (var r = new Uint8Array(e.byteLength), t = e.parts, n = 0, o = 0; o < t.length; o++) {
-            var a = t[o];
-            osc.copyByteArray(a, r, n), n += a.length;
+            var i = t[o];
+            osc.copyByteArray(i, r, n), n += i.length;
         }
         return r;
     }, osc.addDataPart = function(e, r) {
@@ -201,24 +199,24 @@ var osc = osc || {};
             byteLength: 0,
             parts: []
         }, r.metadata || (e = osc.annotateArguments(e));
-        for (var n = ",", o = t.parts.length, a = 0; a < e.length; a++) {
-            var i = e[a];
+        for (var n = ",", r = t.parts.length, o = 0; o < e.length; o++) {
+            var i = e[o];
             n += osc.writeArgument(i, t);
         }
-        r = osc.writeString(n);
-        return t.byteLength += r.byteLength, t.parts.splice(o, 0, r), t;
+        var a = osc.writeString(n);
+        return t.byteLength += a.byteLength, t.parts.splice(r, 0, a), t;
     }, osc.readMessage = function(e, r, t) {
         r = r || osc.defaults;
-        var n = osc.dataView(e, e.byteOffset, e.byteLength), e = osc.readString(n, t = t || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), n = osc.readString(e, t = t || {
             idx: 0
         });
-        return osc.readMessageContents(e, n, r, t);
+        return osc.readMessageContents(n, e, r, t);
     }, osc.readMessageContents = function(e, r, t, n) {
         if (0 !== e.indexOf("/")) throw new Error("A malformed OSC address was found while reading an OSC message. String was: " + e);
-        n = osc.readArguments(r, t, n);
+        r = osc.readArguments(r, t, n);
         return {
             address: e,
-            args: 1 === n.length && t.unpackSingleArgs ? n[0] : n
+            args: 1 === r.length && t.unpackSingleArgs ? r[0] : r
         };
     }, osc.collectMessageParts = function(e, r, t) {
         return t = t || {
@@ -227,8 +225,8 @@ var osc = osc || {};
         }, osc.addDataPart(osc.writeString(e.address), t), osc.collectArguments(e.args, r, t);
     }, osc.writeMessage = function(e, r) {
         if (r = r || osc.defaults, !osc.isValidMessage(e)) throw new Error("An OSC message must contain a valid address. Message was: " + JSON.stringify(e, null, 2));
-        r = osc.collectMessageParts(e, r);
-        return osc.joinParts(r);
+        e = osc.collectMessageParts(e, r);
+        return osc.joinParts(e);
     }, osc.isValidMessage = function(e) {
         return e.address && 0 === e.address.indexOf("/");
     }, osc.readBundle = function(e, r, t) {
@@ -247,28 +245,27 @@ var osc = osc || {};
     }, osc.writeBundle = function(e, r) {
         if (!osc.isValidBundle(e)) throw new Error("An OSC bundle must contain 'timeTag' and 'packets' properties. Bundle was: " + JSON.stringify(e, null, 2));
         r = r || osc.defaults;
-        r = osc.collectBundlePackets(e, r);
-        return osc.joinParts(r);
+        e = osc.collectBundlePackets(e, r);
+        return osc.joinParts(e);
     }, osc.isValidBundle = function(e) {
         return void 0 !== e.timeTag && void 0 !== e.packets;
     }, osc.readBundleContents = function(e, r, t, n) {
-        for (var o = osc.readTimeTag(e, t), a = []; t.idx < n; ) {
-            var i = osc.readInt32(e, t), i = t.idx + i, i = osc.readPacket(e, r, t, i);
-            a.push(i);
+        for (var o = osc.readTimeTag(e, t), i = []; t.idx < n; ) {
+            var a = osc.readInt32(e, t), a = t.idx + a, a = osc.readPacket(e, r, t, a);
+            i.push(a);
         }
         return {
             timeTag: o,
-            packets: a
+            packets: i
         };
     }, osc.readPacket = function(e, r, t, n) {
-        var o = osc.dataView(e, e.byteOffset, e.byteLength);
-        n = void 0 === n ? o.byteLength : n;
-        var a = osc.readString(o, t = t || {
+        var e = osc.dataView(e, e.byteOffset, e.byteLength), o = (n = void 0 === n ? e.byteLength : n, 
+        osc.readString(e, t = t || {
             idx: 0
-        }), e = a[0];
-        if ("#" === e) return osc.readBundleContents(o, r, t, n);
-        if ("/" === e) return osc.readMessageContents(a, o, r, t);
-        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + a);
+        })), i = o[0];
+        if ("#" === i) return osc.readBundleContents(e, r, t, n);
+        if ("/" === i) return osc.readMessageContents(o, e, r, t);
+        throw new Error("The header of an OSC packet didn't contain an OSC address or a #bundle string. Header was: " + o);
     }, osc.writePacket = function(e, r) {
         if (osc.isValidMessage(e)) return osc.writeMessage(e, r);
         if (osc.isValidBundle(e)) return osc.writeBundle(e, r);

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
         "ws": "7.5.3"
     },
     "optionalDependencies": {
-        "serialport": "9.2.0"
+        "serialport": "10.4.0"
     },
     "scripts": {
         "test": "npm run node-test && grunt && npm run browser-test",
+        "build": "grunt",
         "node-test": "node tests/node-all-tests.js",
         "browser-test": "testem ci --file tests/testem.json",
         "clean-test": "./clean-npm.sh && npm install && npm test"


### PR DESCRIPTION
This updates serial port to 10.4 where serialport now uses napi.

Serialport has also switching from @serialport/bindings to @serialport/bindings-cpp which also uses napi and prebuildify